### PR TITLE
Only run on PHP files

### DIFF
--- a/linters/phpcs/index.js
+++ b/linters/phpcs/index.js
@@ -54,6 +54,7 @@ module.exports = codepath => {
 			'installed_paths',
 			'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer',
 			`--standard=${standard}`,
+			`--extensions=php`,
 			'--report=json',
 			codepath
 		];


### PR DESCRIPTION
While we are sorting out JS linting, which is pretty broken due to ESLint / PHPCS integration, we should atleast stop blowing up PRs and just run on PHP.