### PR TITLE
Fix a couple of issues with ESLint

### DIFF
--- a/src/linters/eslint/index.js
+++ b/src/linters/eslint/index.js
@@ -26,6 +26,11 @@ const formatOutput = ( data, codepath ) => {
 	const files = {};
 	// console.log( data );
 	data.results.forEach( result => {
+		// Exclude any empty files.
+		if ( ! result.messages.length ) {
+			return;
+		}
+
 		const relPath = path.relative( codepath, result.filePath );
 		files[ relPath ] = result.messages.map( formatMessage );
 	} );


### PR DESCRIPTION
* `severity` is actually 1 for warnings and 2 for errors; I accidentally copied phpcs' codes
* ESLint includes all files, which makes higher-level processing a bit more painful, so we should exclude it at the lower level

Finally fixes #9.