### PR TITLE
Add support for HM_LINTER_GITHUB_TOKEN

### DIFF
--- a/scripts/test-commit.js
+++ b/scripts/test-commit.js
@@ -28,6 +28,13 @@ const main = argv => {
 	};
 	const github = new githubApi();
 
+	if ( process.env.HM_LINTER_GITHUB_TOKEN ) {
+		github.authenticate( {
+			type: 'token',
+			token: process.env.HM_LINTER_GITHUB_TOKEN,
+		} );
+	}
+
 	run( pushConfig, github )
 		.then( results => {
 			const summary = formatSummary( results );

--- a/scripts/test-pr.js
+++ b/scripts/test-pr.js
@@ -23,6 +23,14 @@ const main = argv => {
 	}
 
 	const github = new githubApi();
+
+	if ( process.env.HM_LINTER_GITHUB_TOKEN ) {
+		github.authenticate( {
+			type: 'token',
+			token: process.env.HM_LINTER_GITHUB_TOKEN,
+		} );
+	}
+
 	github.pullRequests.get( { owner, repo, number } )
 		.then( ( { data } ) => {
 			const commit = data.head.sha;


### PR DESCRIPTION
Forgot to add this in #17, but this is required for any private repos.