### PR TITLE
Exclude common asset file types.

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -72,6 +72,7 @@ module.exports = async ( pushConfig, github ) => {
 		cwd:   extractDir,
 		file:  tarball,
 		strip: 1,
+		filter: path => ! path.match( /\.(jpg|jpeg|png|gif|woff|swf|flv|fla|woff|svg|otf||ttf|eot|swc|xap)$/ ),
 	} );
 
 	// Delete the now-unneeded tarball.


### PR DESCRIPTION
We don't need to extract all files from the archive. As we have a limited amount of space (about 300MB) we should only extract things we need. We _could_ whitelist, but doing so is tricky as it's js, php, but also XML and .elint* files, and potentially others. So in the meantime I think it's easier to blacklist certain extenions.