### PR TITLE
Reuse commits for local testing

### DIFF
--- a/scripts/test-commit.js
+++ b/scripts/test-commit.js
@@ -35,7 +35,7 @@ const main = argv => {
 		} );
 	}
 
-	run( pushConfig, github )
+	run( pushConfig, github, true )
 		.then( results => {
 			const summary = formatSummary( results );
 			if ( results.passed ) {


### PR DESCRIPTION
When you're linting the same thing repeatedly, it's super useful to allow reuse. Since commits are unique anyway, this is generally safe, but for now I've only enabled locally.

Tempting to make this a CLI flag, but we'd need to parse it out, which I can't be bothered with.