### PR TITLE
Compare review to the latest review, not first

### DIFF
--- a/src/review.js
+++ b/src/review.js
@@ -24,6 +24,7 @@ async function getPreviousRun( github, owner, repo, number ) {
 
 	return reviews
 		.filter( review => review.user.type === 'Bot' && ( review.user.login === 'hm-linter' || review.user.login === 'hm-linter-development' ) )
+		.reverse()
 		.map( review => metadata.parse( review.body ) )
 		.find( data => !! data );
 }


### PR DESCRIPTION
The reviews API returns items chronologically, not reverse-chronologically, so we need to reverse before picking an item.

Fixes #39.