### PR TITLE
Add the HM standard to the installed paths

### DIFF
--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -53,7 +53,7 @@ module.exports = codepath => {
 			PHPCS_PATH,
 			'--runtime-set',
 			'installed_paths',
-			'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer,vendor/humanmade/coding-standards',
+			'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer,vendor/humanmade/coding-standards/HM',
 			`--standard=${standard}`,
 			'--report=json',
 			codepath


### PR DESCRIPTION
This means custon phpcs configs can refer to it by name "HM" rather than path, as one would want to do "WordPress-Core" etc.