### PR TITLE
Add eslint-config-humanmade peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,15 @@
 {
   "private": true,
   "dependencies": {
+    "babel-eslint": "^7.0.0",
     "babel-polyfill": "6.16.0",
     "eslint": "^4.19.0",
     "eslint-config-humanmade": "^0.4.0",
+    "eslint-config-react-app": "^0.5.0",
+    "eslint-plugin-flowtype": "^2.21.0",
+    "eslint-plugin-import": "^2.0.1",
+    "eslint-plugin-jsx-a11y": "^2.2.3",
+    "eslint-plugin-react": "^6.4.1",
     "parse-diff": "^0.4.0",
     "pify": "^3.0.0",
     "probot": "^4.1.0",


### PR DESCRIPTION
@peterwilsoncc noticed this; I missed adding the peer dependencies for eslint-config-humanmade when we removed the old node_modules.