### PR TITLE
Add script to get installations

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-polyfill": "6.16.0",
     "babel-preset-es2015": "6.16.0",
     "babel-preset-stage-0": "6.16.0",
+    "chalk": "^2.4.1",
     "dotenv": "^5.0.1"
   },
   "scripts": {

--- a/scripts/meta.js
+++ b/scripts/meta.js
@@ -1,0 +1,44 @@
+const chalk = require( 'chalk' );
+
+const util = require( './util' );
+
+const client = util.createClient();
+
+// Gather app metadata
+async function getMetadata() {
+	const response = await client.request( {
+		url: '/app',
+	} );
+	return response.data;
+}
+
+// Gather all installations from the API
+async function getInstalls() {
+	const response = await client.request( {
+		url: '/app/installations',
+	} );
+	const { data } = response;
+
+	while ( client.hasNextPage( response ) ) {
+		response = await client.getNextPage( response );
+		data = data.concat( response.data )
+	}
+
+	return data;
+}
+
+const installPromise = getInstalls();
+
+getMetadata().then( metadata => {
+	console.log( `Data for ${ chalk.green.bold( metadata.name ) } (ID ${ metadata.id })\n` );
+
+	installPromise
+		.then( installs => {
+			console.log( 'Installed on:' );
+			installs.forEach( install => console.log( chalk.grey( '• ' ) + install.account.login ) );
+		} )
+		.catch( err => {
+			console.log( 'Cannot fetch installs' );
+			console.log( err );
+		} );
+} );

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -1,0 +1,32 @@
+const fs = require( 'fs' );
+const jwt = require( 'jsonwebtoken' );
+const Octokit = require( '@octokit/rest' );
+
+const id = process.env.APP_ID || 8936;
+const certName = id === 8936 ? 'development.private-key.pem' : 'private-key.pem';
+const cert = fs.readFileSync( certName, 'utf8' );
+
+function createToken() {
+	const payload = {
+		exp: Math.floor( Date.now() / 1000 ) + 60,  // JWT expiration time
+		iat: Math.floor( Date.now() / 1000 ),       // Issued at time
+		iss: id                                     // GitHub App ID
+	};
+
+	// Sign with RSA SHA256
+	return jwt.sign( payload, cert, { algorithm: 'RS256' } );
+}
+
+function createClient() {
+	const github = new Octokit();
+	github.authenticate( {
+		type: 'integration',
+		token: createToken(),
+	} );
+
+	return github;
+}
+
+module.exports = {
+	createClient,
+};


### PR DESCRIPTION
In order to keep track of where linter-bot is activated, we can hit up GitHub's API. I added a util file so we can make some more meta commands if we want.