### PR TITLE
Support distributable config files.

### DIFF
--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -3,7 +3,10 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 
 const CONFIG_NAMES = [
+	'.phpcs.xml',
 	'phpcs.xml',
+	'.phpcs.xml.dist',
+	'phpcs.xml.dist',
 	'phpcs.ruleset.xml',
 ];
 


### PR DESCRIPTION
PHPCS does not only work with `phpcs.xml` and `ruleset.xml` files, but also with (special) [distributable files](https://github.com/squizlabs/PHP_CodeSniffer/blob/87ba8779e7335a491f14917d1604e81dfe3a2890/src/Config.php#L342-L347), ending with `xml.dist`. These are usually the ones that get included in a project, and then people can create local variants (without the `.dist` suffix) that take precendence over these distributable ones.

I included `phpcs.xml.dist`, which I am using in all of the projects I am involved in, and also the special (legacy?) file names starting with a dot (i.e., `.phpcs.xml` and `.phpcs.xml.dist`).