### PR TITLE
Override progress (and verbosity) flag.

### DIFF
--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -51,6 +51,7 @@ module.exports = standardPath => codepath => {
 		// const standard = 'PSR2'; //...
 		const args = [
 			phpcsPath,
+			'-q',
 			'--runtime-set',
 			'installed_paths',
 			'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer',


### PR DESCRIPTION
This should resolve #55.

The `-q` CLI arg will disable both the _progress_ flag, `-p`, and the _verbosity_ flags `-v(vv)`.