### PR TITLE
Cross-OS Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "babel-polyfill": "6.16.0",
     "babel-preset-es2015": "6.16.0",
     "babel-preset-stage-0": "6.16.0",
-    "dotenv": "^5.0.1"
+    "dotenv": "^5.0.1",
+    "fs-extra": "^6.0.1"
   },
   "scripts": {
     "build:babel": "( rm -rf build || true ) && mkdir build && babel src --out-dir build --ignore src/linters/phpcs/vendor -D",

--- a/src/linters/index.js
+++ b/src/linters/index.js
@@ -1,5 +1,6 @@
-const fs = require( 'fs' );
+const fs = require( 'fs-extra' );
 const https = require( 'https' );
+const os = require( 'os' );
 const pify = require( 'pify' );
 const tar = require( 'tar' );
 
@@ -10,7 +11,8 @@ const available = {
 	phpcs: require( './phpcs' ),
 };
 
-const STANDARDS_DIR = '/tmp/hmlinter-standards';
+const tmpdir = os.tmpdir();
+const STANDARDS_DIR = `${tmpdir}/hmlinter-standards`;
 const BASE_URL = 'https://make.hmn.md/hmlinter/standards';
 
 const httpGet = ( ...args ) => {
@@ -29,7 +31,7 @@ const httpGet = ( ...args ) => {
 
 const downloadFile = async ( url, filename ) => {
 	if ( ! fs.existsSync( STANDARDS_DIR ) ) {
-		await pify( fs.mkdir )( STANDARDS_DIR );
+		await pify( fs.mkdirs )( STANDARDS_DIR );
 	}
 
 	console.log( `Fetching ${ url }` );
@@ -54,10 +56,10 @@ const prepareLinter = async ( linter, version ) => {
 	console.log( `Extracting standard to ${ directory }` );
 
 	if ( ! fs.existsSync( directory ) ) {
-		await pify( fs.mkdir )( directory );
+		await pify( fs.mkdirs )( directory );
 	}
 
-	const extracted = await tar.extract( {
+	await tar.extract( {
 		cwd: directory,
 		file: tarball,
 	} );

--- a/src/run.js
+++ b/src/run.js
@@ -1,5 +1,6 @@
-const fs = require( 'fs' );
+const fs = require( 'fs-extra' );
 const https = require( 'https' );
+const os = require( 'os' );
 const path = require( 'path' );
 const pify = require( 'pify' );
 const rimraf = require( 'rimraf' );
@@ -10,11 +11,12 @@ const realpath = pify( fs.realpath );
 const getLinters = require( './linters' );
 const { DOWNLOAD_DIR, saveDownloadedFile } = require( './util' );
 
-const REPO_DIR = '/tmp/repos';
+const tmpdir = os.tmpdir();
+const REPO_DIR = `${tmpdir}/repos`;
 
 [ DOWNLOAD_DIR, REPO_DIR ].forEach( dir => {
 	try {
-		fs.mkdir( dir, () => {} );
+		fs.mkdirs( dir, () => {} );
 	}
 	catch ( e ) {
 		console.log( e );
@@ -37,7 +39,7 @@ const downloadRepo = async ( extractDir, pushConfig, github ) => {
 	const tarball = await saveDownloadedFile( archive.data, filename );
 
 	try {
-		await pify( fs.mkdir )( extractDir );
+		await pify( fs.mkdirs )( extractDir );
 	} catch ( e ) {
 		// Ignore if it already exists.
 	}


### PR DESCRIPTION
Also see [`#dev`](https://hmn.slack.com/archives/C03K3J34A/p1528475314000233) in Slack.

----

The current version of linter-bot doesn't run on Windows, and potentially other OS.

To start fixing this, I made use of `fs-extra.mkdirs()` (instead of `fs.mkdir()`), and also `os.tmpdir()` to read the actual temp directory.

For me (Windows), this is still not yet working completely. This is because some of the files in the `*-latest.tar.gz` files are symlinks, and not actual files. Can we please change that?