### PR TITLE
Move helpers to common probot library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,54 +1,12 @@
-require("babel-polyfill");
+require( 'babel-polyfill' );
 
-const fs = require('fs')
-const cert = fs.readFileSync('private-key.pem', 'utf8')
-process.env['PATH'] = process.env['PATH'] + ':' + process.env['LAMBDA_TASK_ROOT'] + '/bin'
+const { probot } = require( '@humanmade/probot-util' );
+
 // Probot setup
-const createProbot = require('probot');
-const probot = createProbot({
-  id: process.env.APP_ID,
-  secret: process.env.WEBHOOK_SECRET,
-  cert: cert,
-  port: 0
-})
+const bot = probot.create();
 
-// Load Probot plugins from the `./plugin` folder
-// You can specify plugins in an `index.js` file or your own custom file by providing
-// a primary entry point in the "main" field of `./plugin/package.json`
-// https://docs.npmjs.com/files/package.json#main
-probot.load(require('./build'));
+// Load Probot plugins from the `./build` folder
+bot.load( require( './build' ) );
 
 // Lambda Handler
-module.exports.probotHandler = function (event, context, callback) {
-  console.log( JSON.stringify( event, null, 2 ) );
-  // Determine incoming webhook event type
-  // Checking for different cases since node's http server is lowercasing everything
-  const e = event.headers['x-github-event'] || event.headers['X-GitHub-Event']
-
-  // Convert the payload to an Object if API Gateway stringifies it
-  event.body = (typeof event.body === 'string') ? JSON.parse(event.body) : event.body
-
-  try {
-    if ( ! e || ! event.body ) {
-      throw new Error( 'Payload not present or malformed.' );
-    }
-    // Do the thing
-    probot.receive({
-      event: e,
-      payload: event.body
-    })
-    .then(( err ) => {
-      const res = {
-        statusCode: 200,
-        body: JSON.stringify({
-          message: 'Executed'
-        })
-      }
-      callback(null, res)
-    })
-
-  } catch (err) {
-    callback(err)
-  }
-
-}
+module.exports.probotHandler = probot.buildHandler( bot );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "dependencies": {
+    "@humanmade/probot-util": "^0.0.1",
     "babel-polyfill": "6.16.0",
     "lodash.chunk": "^4.2.0",
     "parse-diff": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@humanmade/probot-util": "^0.0.2",
+    "@humanmade/probot-util": "^0.0.3",
     "babel-polyfill": "6.16.0",
     "lodash.chunk": "^4.2.0",
     "parse-diff": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@humanmade/probot-util": "^0.0.1",
+    "@humanmade/probot-util": "^0.0.2",
     "babel-polyfill": "6.16.0",
     "lodash.chunk": "^4.2.0",
     "parse-diff": "^0.4.0",

--- a/src/linters/index.js
+++ b/src/linters/index.js
@@ -1,9 +1,8 @@
+const probotUtil = require( '@humanmade/probot-util' );
 const fs = require( 'fs' );
 const https = require( 'https' );
 const pify = require( 'pify' );
 const tar = require( 'tar' );
-
-const { saveDownloadedFile } = require( '../util' );
 
 const available = {
 	eslint: require( './eslint' ),
@@ -40,7 +39,7 @@ const downloadFile = async ( url, filename ) => {
 	}
 
 	console.log( `Saving to ${ filename }` );
-	return await saveDownloadedFile( res.body, filename );
+	return await probotUtil.file.saveDownloadedFile( res.body, filename );
 };
 
 const prepareLinter = async ( linter, version ) => {

--- a/src/util.js
+++ b/src/util.js
@@ -3,7 +3,6 @@ const path = require( 'path' );
 
 const githubApi = require( '@octokit/rest' );
 
-const DOWNLOAD_DIR = '/tmp/downloads';
 const GIST_ACCESS_TOKEN = process.env.GIST_ACCESS_TOKEN || null;
 
 function combineLinters( results ) {
@@ -42,19 +41,7 @@ const createGist = async ( description, filename, content ) => {
 	return response.data.html_url;
 };
 
-const saveDownloadedFile = ( buffer, filename ) => {
-	const downloadPath = path.join( DOWNLOAD_DIR, filename );
-	return new Promise( ( resolve, reject ) => {
-		const handle = fs.createWriteStream( downloadPath );
-		handle.end( buffer, () => {
-			handle.close( () => resolve( downloadPath ) );
-		} );
-	} );
-};
-
 module.exports = {
-	DOWNLOAD_DIR,
 	combineLinters,
 	createGist,
-	saveDownloadedFile,
 };

--- a/start-development.js
+++ b/start-development.js
@@ -1,24 +1,12 @@
 require( 'babel-polyfill' );
-require( 'dotenv' ).config();
 
-const fs = require('fs')
+const { probot } = require( '@humanmade/probot-util' );
 const path = require( 'path' );
-
-const mainPlugin = require( './src' );
-
-const cert = fs.readFileSync( 'development.private-key.pem', 'utf8' );
 
 process.env['PATH'] = process.env['PATH'] + ':' + path.join( __dirname, 'bin' );
 
 // Probot setup
-const createProbot = require( 'probot' );
-const probot = createProbot( {
-	id: 8936,
-	secret: 'development',
-	cert: cert,
-	port: process.env.PORT || 5757,
-	webhookProxy: 'https://smee.io/rpFoxbfDjkw5Srji',
-} );
+const bot = probot.create();
 
-probot.load( mainPlugin );
-probot.start();
+bot.load( require( './src' ) );
+bot.start();


### PR DESCRIPTION
Started working on https://github.com/humanmade/probot-util to extract some of the common utilities from linter-bot so we can reuse them for other bots.

In time, I want to split that repo down to more granular packages too, but we'll get there.