### PR TITLE
Remove Composer Installation Instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ To get started on development of hm-linter:
 
 1. Clone this repository
 2. `npm install` or `yarn install` the dependencies
-3. `cd src/linters/phpcs && composer install` to download the HM Coding Standards
 
 
 ### Testing


### PR DESCRIPTION
There is no longer a Composer file to pull in the PHPCS standards, making this installation line no longer applicable.

Related to #68 