### PR TITLE
Use dependencies from ESLint package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@humanmade/probot-util": "^0.0.4",
     "babel-polyfill": "6.16.0",
     "lodash.chunk": "^4.2.0",
+    "module-alias": "^2.1.0",
     "parse-diff": "^0.4.0",
     "pify": "^3.0.0",
     "probot": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:bin": "aws s3 sync s3://hm-linter/bin ./bin && chmod +x ./bin/*",
     "build:npm": "docker run --rm -v \"${PWD}\":/var/task lambci/lambda:build-nodejs8.10 npm install",
     "build": "npm run build:babel && npm run build:bin && npm run build:npm",
+    "clean:package": "( test -f lambda-function.zip && rm lambda-function.zip ) || true",
     "deploy:check": "test -f bin/php && test -f production.private-key.pem",
     "deploy:check-dev": "test -f bin/php && test -f development.private-key.pem",
     "deploy:package": "zip --symlinks -9 -x lambda-function.zip -x \"src/*\" -r lambda-function *",
@@ -34,8 +35,8 @@
     "deploy:package-production": "npm run deploy:package && cp production.private-key.pem private-key.pem && zip -9 lambda-function private-key.pem",
     "deploy:push": "aws lambda update-function-code --function-name hm-linter --region us-east-1 --zip-file fileb://lambda-function.zip",
     "deploy:push-dev": "aws lambda update-function-code --function-name hm-linter-development --region us-east-1 --zip-file fileb://lambda-function.zip",
-    "deploy": "npm run build && npm run deploy:check && npm run deploy:package-production && npm run deploy:push",
-    "deploy:dev": "npm run build && npm run deploy:check-dev && npm run deploy:package-dev && npm run deploy:push-dev",
+    "deploy": "npm run clean:package && npm run build && npm run deploy:check && npm run deploy:package-production && npm run deploy:push",
+    "deploy:dev": "npm run clean:package && npm run build && npm run deploy:check-dev && npm run deploy:package-dev && npm run deploy:push-dev",
     "start": "node start-development.js",
     "test": "docker run -e \"APP_ID=5455\" -e \"WEBHOOK_SECRET=development\" -v \"$PWD\":/var/task lambci/lambda:nodejs8.10 index.probotHandler \"$AWS_LAMBDA_EVENT_BODY\""
   }


### PR DESCRIPTION
This replaces our hack with a more stable way to load dependencies, as well as now correctly resolving `eslint-config-humanmade` to the root package directory.

Fixes #86, might help with #67 too.