### PR TITLE
Clean up tmp directories after running

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,21 @@
+const pify = require( 'pify' );
+const rimraf = require( 'rimraf' );
+
 const { onAdd, onCheck, onPush, onOpenPull, onUpdatePull } = require( './hooks' );
 
+const clean = async () => {
+	// Clean up the tmp directories.
+	console.log( 'Cleaning up /tmp' );
+	const rmrf = pify( rimraf );
+	await rmrf( '/tmp/downloads' );
+	await rmrf( '/tmp/repos' );
+};
+const withClean = func => ( ...args ) => func( ...args ).then( () => clean() );
+
 module.exports = robot => {
-	robot.on( 'installation_repositories.added', onAdd );
-	robot.on( [ 'check_suite.requested', 'check_suite.rerequested' ], onCheck );
-	robot.on( 'check_run.rerequested', onCheck );
-	robot.on( 'pull_request.opened', onOpenPull );
-	robot.on( 'pull_request.synchronize', onUpdatePull );
+	robot.on( 'installation_repositories.added', withClean( onAdd ) );
+	robot.on( [ 'check_suite.requested', 'check_suite.rerequested' ], withClean( onCheck ) );
+	robot.on( 'check_run.rerequested', withClean( onCheck ) );
+	robot.on( 'pull_request.opened', withClean( onOpenPull ) );
+	robot.on( 'pull_request.synchronize', withClean( onUpdatePull ) );
 };


### PR DESCRIPTION
This cleans up the tmp directories after running. I'm unable to fully test re-running locally, so this may still break there, but at least it should be consistent.