### PR TITLE
Force eslint-config-humanmade to use correct directory if not found

### DIFF
--- a/src/linters/eslint/index.js
+++ b/src/linters/eslint/index.js
@@ -47,6 +47,16 @@ module.exports = standardPath => codepath => {
 	moduleAlias.addPath( `${ standardPath }/node_modules` );
 	moduleAlias.addAlias( 'eslint-config-humanmade', standardPath );
 
+	const actualStandardPath = require.resolve( 'eslint-config-humanmade' );
+	const origFindPath = Module._findPath;
+	Module._findPath = ( name, ...args ) => {
+		const path = origFindPath( name, ...args );
+		if ( ! path && name === 'eslint-config-humanmade' ) {
+			return actualStandardPath;
+		}
+		return path;
+	};
+
 	const { CLIEngine } = require( 'eslint' );
 	const engine = new CLIEngine( options );
 
@@ -68,6 +78,7 @@ module.exports = standardPath => codepath => {
 
 		// Reset path loader.
 		moduleAlias.reset();
+		Module._findPath = origFindPath;
 
 		resolve( formatOutput( output, codepath ) );
 	} );


### PR DESCRIPTION
As it turns out, when ESLint tries to look up `eslint-config-humanmade` it fails, as ESLint is [using an internal method to resolve modules](https://github.com/eslint/eslint/blob/b9aabe34311f6189b87c9d8a1aa40f3513fed773/lib/util/module-resolver.js#L64-L69).

I didn't catch this in testing, as it only occurs if you have a repo with a custom eslintconfig which `extends` the config. If you don't have a config file or you're not extending, then it works just fine.