### PR TITLE
Adding WordPress VIP coding standards to the list of available standards

### DIFF
--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -56,7 +56,7 @@ module.exports = standardPath => codepath => {
 			phpcsPath,
 			'--runtime-set',
 			'installed_paths',
-			'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer,vendor/humanmade/coding-standards/HM',
+			'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer,vendor/humanmade/coding-standards/HM,vendor/automattic/vipwpcs',
 			`--standard=${standard}`,
 			'--report=json',
 			codepath


### PR DESCRIPTION
Adds the WordPress VIP standards to the list of available standards.

@rmccue I am not sure if this is going to cause issues though since the repo can specify the version of the coding standards in their config. I merged https://github.com/humanmade/coding-standards/pull/129 but am unsure if there is even a way to specify the version to be `master` in our hm-linter config instead of a tagged version or if we should be just tagging a new version there.

It might be that your suggestion to do this in the hm-linter packaging script is the better way to do this to avoid issues with using an older version that does not have that standards as a dependency.

Let me know what you think.