### PR TITLE
Revert "VIP Coding Standards Path"

### DIFF
--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -56,7 +56,7 @@ module.exports = standardPath => codepath => {
 			phpcsPath,
 			'--runtime-set',
 			'installed_paths',
-			'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer,vendor/humanmade/coding-standards/HM,vendor/automattic/vipwpcs',
+			'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer,vendor/humanmade/coding-standards/HM',
 			`--standard=${standard}`,
 			'--report=json',
 			codepath


### PR DESCRIPTION
In #94, we added the new path for the VIPCS coding standards, which should have failed to fetch silently via PHPCS if the path didn't exist in older versions and would have worked fine for backwards compatibility.

However, [PHPCS only added silent continuing in v3.3.0](https://github.com/squizlabs/PHP_CodeSniffer/commit/e10bd1661adc347658b393689c951f1101ae609b), which we only bumped to in v0.6.0 of our coding standards. This all means that 0.5.0/latest and back cannot handle missing `installed_paths` and we need to re-consider how we include these PHPCS paths.

I'm going to revert this code and re-deploy for now.