### PR TITLE
Conditionally adding the VIP WPCS standard to the installed_paths

### DIFF
--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -51,12 +51,19 @@ module.exports = standardPath => codepath => {
 	} ) ).then( rulesetFiles => {
 		const standard = rulesetFiles.find( file => !! file ) || `vendor/humanmade/coding-standards`;
 
+		let installed_paths = 'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer,vendor/humanmade/coding-standards/HM';
+
+		// Only include the VIP WPCS if the path exists within this version of the standards.
+		if ( fs.existsSync( path.join( standardPath, 'vendor', 'automattic', 'vipwpcs' ) ) ) {
+			installed_paths += ',vendor/automattic/vipwpcs';
+		}
+
 		// const standard = 'PSR2'; //...
 		const args = [
 			phpcsPath,
 			'--runtime-set',
 			'installed_paths',
-			'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer,vendor/humanmade/coding-standards/HM',
+			installed_paths,
 			`--standard=${standard}`,
 			'--report=json',
 			codepath


### PR DESCRIPTION
Conditionally adding the VIP WPCS standard to the `installed_paths` if the directory exists for that version of the standards.

I have been having issues setting this up to test locally but I wanted to get this in a PR so it doesn't get lost.