### PR TITLE
Include IDs in summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@humanmade/probot-util": "^0.1.0",
+    "@humanmade/probot-util": "^0.2.0",
     "babel-polyfill": "6.16.0",
     "lodash.chunk": "^4.2.0",
     "module-alias": "^2.1.0",

--- a/src/format.js
+++ b/src/format.js
@@ -184,6 +184,15 @@ const formatAnnotations = ( state, baseUrl ) => {
 	return annotations;
 };
 
+/**
+ * Format request metadata.
+ *
+ * Provides request details as part of the summary, allowing for easier tracing
+ * and debugging.
+ *
+ * @param {Object} context Context object passed to hooks.
+ * @return {String} HTML summary of request metadata.
+ */
 const formatMetadata = context => {
 	const { metadata, reqContext } = context;
 

--- a/src/format.js
+++ b/src/format.js
@@ -184,6 +184,18 @@ const formatAnnotations = ( state, baseUrl ) => {
 	return annotations;
 };
 
+const formatMetadata = context => {
+	const { metadata, reqContext } = context;
+
+	let body = '<details><summary>Request details</summary><ul>';
+	body += `\n<li><strong>GitHub Event ID:</strong> <code>${ metadata.headers['X-GitHub-Delivery'] }</code></li>`;
+	body += `\n<li><strong>API Gateway ID:</strong> <code>${ metadata.requestContext.requestId }</code></li>`;
+	body += `\n<li><strong>Lambda ID:</strong> <code>${ reqContext.awsRequestId }</code></li>`;
+	body += `\n<li><strong>Log Stream:</strong> <code>${ reqContext.logStreamName }</code></li>`;
+	body += '</ul></details>';
+	return body;
+};
+
 const formatWelcome = ( state, gistUrl ) => {
 	let body = `Hi there! Thanks for activating hm-linter on this repo.`
 	body += `\n\nTo start you off, [here's an initial lint report of the repo](${ gistUrl }).`;
@@ -202,6 +214,7 @@ module.exports = {
 	formatAnnotations,
 	formatComparison,
 	formatDetails,
+	formatMetadata,
 	formatReview,
 	formatReviewChange,
 	formatSummary,

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -7,6 +7,7 @@ const { getDiffMapping } = require( './diff' );
 const {
 	formatAnnotations,
 	formatDetails,
+	formatMetadata,
 	formatReview,
 	formatReviewChange,
 	formatSummary,
@@ -149,7 +150,10 @@ const onCheck = async context => {
 				accept: 'application/vnd.github.antiope-preview+json',
 			},
 			input: {
-				output,
+				output: {
+					...output,
+					summary: output.summary + formatMetadata( context ),
+				},
 			}
 		} );
 	};
@@ -167,7 +171,10 @@ const onCheck = async context => {
 				completed_at: ( new Date() ).toISOString(),
 				status: 'completed',
 				conclusion,
-				output,
+				output: {
+					...output,
+					summary: output.summary + formatMetadata( context ),
+				},
 			}
 		} );
 	};

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -137,6 +137,10 @@ const onCheck = async context => {
 			head_branch,
 			head_sha,
 			started_at: ( new Date() ).toISOString(),
+			output: {
+				title: 'Checking…',
+				summary: formatMetadata( context ),
+			},
 		},
 	} );
 


### PR DESCRIPTION
Often it can be a pain to find out exactly what the request was. Let's include the IDs in the summary.

<img width="598" alt="Screen Shot 2019-05-14 at 17 41 56" src="https://user-images.githubusercontent.com/21655/57716040-0394aa00-7670-11e9-9bd2-c42815437f70.png">
