### PR TITLE
Fix weird paths

### DIFF
--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -30,7 +30,9 @@ const formatOutput = ( data, codepath ) => {
 	};
 	const files = {};
 	Object.keys( data.files ).forEach( file => {
-		const relPath = path.relative( codepath, file );
+		// Ensure the path has a leading slash.
+		const fullPath = file.replace( /^([^\/])/,'/$1' );
+		const relPath = path.relative( codepath, fullPath );
 		files[ relPath ] = data.files[ file ].messages.map( formatMessage );
 	} );
 


### PR DESCRIPTION
phpcs has started generating paths without a leading slash, leading to some weird `../../var/tmp/...` paths. I have no idea why it's doing this, but we can just ensure it has a leading slash.