### PR TITLE
Improve ability to reproduce errors locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,60 +110,13 @@ A typical development process looks like this:
 8. Repeat steps 2-7 until your code works.
 
 
-### Testing Payloads
-
-You can test API Gateway payloads against a simulated Lambda environment (again using Docker) to do so:
-
-```sh
-# Run build at least once to download the bin and lib directories
-yarn run build
-
-# Pass a payload to the test command
-yarn run test < fixtures/lambda-test-event.json
-```
-
-**Note:** The format of this JSON data **must** be in API Gateway format; you typically want to copy this from CloudWatch Logs. If you get an `Cannot read property 'x-github-event' of undefined` error, you're passing a GitHub event instead.
-
-
-### Simulation
-
-This repo also includes fixtures for specific events, and you can use Probot's simulation mode to test these. This simulates a webhook request from GitHub, **but uses the live GitHub API**, so be careful. Generally, you should use live testing instead, as it's more powerful. The fixture data included in the repo is from a test repository (rmccue/test-linter).
-
-Note also that both a `.env` and private key are required. You can create your own GitHub App to get these, or ping me (@rmccue) to get the details for `hmlinter`.
-
-Your private key should be saved as `private-key.pem`, and your `.env` should contain this:
-
-```
-APP_ID=5455
-WEBHOOK_SECRET=development
-GIST_ACCESS_TOKEN=...
-```
-
-(You will need to generate your own `GIST_ACCESS_TOKEN`: this is a GitHub personal access token with `gist` scope.)
-
-To test a `push` webhook:
-
-```
-node_modules/.bin/probot simulate push fixtures/push.json ./plugin/linter.js
-```
-
-To test a `pull_request.open` webhook:
-
-```
-node_modules/.bin/probot simulate pull_request fixtures/pull_request.opened.json ./plugin/linter.js
-```
-
-To test a `pull_request.synchronize` webhook:
-
-```
-node_modules/.bin/probot simulate pull_request fixtures/pull_request.synchronize.json ./plugin/linter.js
-```
-
 ### Replicating production issues
 
-The first step to replicating production issues is to understand the request being sent to hm-linter.
+The first step to replicating production issues is to understand the request being sent to hm-linter. Note that when running against these events, you are **testing against the live GitHub API**, so be careful.
 
-Access the CloudWatch Logs for hm-linter (ask the Cloud team for access) and find the request you received. If you have the AWS CLI installed, you can do this by running the `scripts/get-logs.js` command and passing the Lambda (request) ID.
+Access the CloudWatch Logs for hm-linter (ask the Cloud team for access) and find the request you received. If you have the AWS CLI installed, you can do this by running the `scripts/get-logs.js` command.
+
+Each check status page lists the various request IDs. The **Lambda ID** is the ID you need for pulling down the relevant logs and data.
 
 This will write the logs to `{id}.log`, and save the raw data to `{id}.json`.
 
@@ -182,7 +135,7 @@ Log saved to:           deadbeef-badd-ecaf-dead-beefbaddecaf.log
 Raw data saved to:      deadbeef-badd-ecaf-dead-beefbaddecaf.json
 ```
 
-You can then run the handler against a simulated Lambda environment locally:
+You can then run the handler against a simulated Lambda environment locally (using Docker):
 
 ```
 # Run build at least once:
@@ -191,6 +144,9 @@ npm run build
 # Run the handler.
 npm run test < deadbeef-badd-ecaf-dead-beefbaddecaf.json
 ```
+
+**Note:** The format of the JSON data passed to `test` **must** be in API Gateway format (i.e. from the get-logs script). If you get an `Cannot read property 'x-github-event' of undefined` error, you're passing a GitHub event instead (i.e. from Smee).
+
 
 ### Deployment
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ node_modules/.bin/probot simulate pull_request fixtures/pull_request.synchronize
 
 The first step to replicating production issues is to understand the request being sent to hm-linter.
 
-Access the CloudWatch Logs for hm-linter (ask the Cloud team for access) and find the request you received. If you have the AWS CLI installed, you can do this by running the `scripts/get-logs.js` command and passing the request ID.
+Access the CloudWatch Logs for hm-linter (ask the Cloud team for access) and find the request you received. If you have the AWS CLI installed, you can do this by running the `scripts/get-logs.js` command and passing the Lambda (request) ID.
 
 This will write the logs to `{id}.log`, and save the raw data to `{id}.json`.
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,11 @@ Access the CloudWatch Logs for hm-linter (ask the Cloud team for access) and fin
 This will write the logs to `{id}.log`, and save the raw data to `{id}.json`.
 
 ```sh
-// For request deadbeef-badd-ecaf-dead-beefbaddecaf:
+# For request deadbeef-badd-ecaf-dead-beefbaddecaf:
 node scripts/get-logs.js deadbeef-badd-ecaf-dead-beefbaddecaf
+
+# By default, this will only check the last 48 hours; to override, set HOUR_LIMIT:
+HOUR_LIMIT=192 node scripts/get-logs.js deadbeef-badd-ecaf-dead-beefbaddecaf
 ```
 
 ```

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "deploy": "npm run clean:package && npm run build && npm run deploy:check && npm run deploy:package-production && npm run deploy:push",
     "deploy:dev": "npm run clean:package && npm run build && npm run deploy:check-dev && npm run deploy:package-dev && npm run deploy:push-dev",
     "start": "node start-development.js",
-    "test": "docker run -e \"APP_ID=5455\" -e \"WEBHOOK_SECRET=development\" -v \"$PWD\":/var/task lambci/lambda:nodejs8.10 index.probotHandler \"$AWS_LAMBDA_EVENT_BODY\""
+    "test": "docker run -e \"APP_ID=5455\" -e \"WEBHOOK_SECRET=development\" -e \"DOCKER_LAMBDA_USE_STDIN=1\" -i -v \"$PWD\":/var/task lambci/lambda:nodejs8.10 index.probotHandler"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "build:babel": "( rm -rf build || true ) && mkdir build && babel src --out-dir build --ignore src/linters/phpcs/vendor -D",
+    "build:babel-watch": "babel src --out-dir build --ignore src/linters/phpcs/vendor -D -w",
     "build:bin": "aws s3 sync s3://hm-linter/bin ./bin && chmod +x ./bin/*",
     "build:npm": "docker run --rm -v \"${PWD}\":/var/task lambci/lambda:build-nodejs8.10 npm install",
     "build": "npm run build:babel && npm run build:bin && npm run build:npm",

--- a/scripts/get-logs.js
+++ b/scripts/get-logs.js
@@ -1,0 +1,77 @@
+const child_process = require( 'child_process' );
+const fs = require( 'fs' );
+
+const reqId = process.argv[2];
+
+const now = Math.floor( Date.now() / 1000 );
+const start = now - ( 60 * 60 * 2 );
+const region = 'us-east-1';
+const group = '/aws/lambda/hm-linter';
+const query = `fields @message | sort @timestamp asc | filter @requestId = '${ reqId }'`;
+
+
+process.stderr.write( `Querying for ${ reqId }\n` );
+const proc = child_process.spawnSync(
+	'aws',
+	[
+		'logs',
+		'start-query',
+		'--region',
+		region,
+		'--log-group-name',
+		group,
+		'--start-time',
+		start,
+		'--end-time',
+		now,
+		'--query-string',
+		query,
+	]
+);
+
+if ( proc.status !== 0 ) {
+	console.log( '' + proc.output[2] );
+	return process.exit( 1 );
+}
+
+const { queryId } = JSON.parse( proc.output[1] );
+
+const dataRegex = /^.+?\t.+?\t(\{.+)/s;
+
+process.stderr.write( 'Waiting for results…\n' );
+setTimeout( function () {
+	const viewProc = child_process.spawnSync(
+		'aws',
+		[
+			'logs',
+			'get-query-results',
+			'--region',
+			region,
+			'--query-id',
+			queryId
+		]
+	);
+	if ( viewProc.status !== 0 ) {
+		console.log( '' + viewProc.output[2] );
+		return process.exit( 1 );
+	}
+
+	const data = JSON.parse( viewProc.output[1] );
+
+	let rawData = null;
+	data.results.slice( 0, 3 ).forEach( row => {
+		const message = row.find( f => f.field === '@message' ).value;
+
+		if ( ! rawData ) {
+			const hasMatch = message.match( dataRegex );
+			if ( hasMatch ) {
+				rawData = hasMatch[1];
+			}
+		}
+
+		process.stdout.write( message );
+	} );
+
+	fs.writeFileSync( `./${ reqId }.json`, rawData );
+	process.stderr.write( `Raw data saved to ${ reqId }.json\n` );
+}, 2000 );

--- a/scripts/get-logs.js
+++ b/scripts/get-logs.js
@@ -2,9 +2,10 @@ const child_process = require( 'child_process' );
 const fs = require( 'fs' );
 
 const reqId = process.argv[2];
+const HOUR_LIMIT = process.env.HOUR_LIMIT || 48;
 
 const now = Math.floor( Date.now() / 1000 );
-const start = now - ( 60 * 60 * 48 );
+const start = now - ( 60 * 60 * HOUR_LIMIT );
 const region = 'us-east-1';
 const group = '/aws/lambda/hm-linter';
 const query = `fields @message | sort @timestamp asc | filter @requestId = '${ reqId }'`;

--- a/scripts/get-logs.js
+++ b/scripts/get-logs.js
@@ -40,6 +40,7 @@ const dataRegex = /^.+?\t.+?\t(\{.+)/s;
 
 process.stderr.write( 'Waiting for results…\n' );
 setTimeout( function () {
+	const logFile = fs.openSync( `./${ reqId }.log`, 'w' );
 	const viewProc = child_process.spawnSync(
 		'aws',
 		[
@@ -69,9 +70,11 @@ setTimeout( function () {
 			}
 		}
 
-		process.stdout.write( message );
+		fs.writeSync( logFile, message );
 	} );
 
+	fs.closeSync( logFile );
 	fs.writeFileSync( `./${ reqId }.json`, rawData );
-	process.stderr.write( `Raw data saved to ${ reqId }.json\n` );
+	process.stderr.write( `Log saved to:\t\t${ reqId }.log\n` );
+	process.stderr.write( `Raw data saved to:\t${ reqId }.json\n` );
 }, 2000 );

--- a/scripts/get-logs.js
+++ b/scripts/get-logs.js
@@ -4,7 +4,7 @@ const fs = require( 'fs' );
 const reqId = process.argv[2];
 
 const now = Math.floor( Date.now() / 1000 );
-const start = now - ( 60 * 60 * 2 );
+const start = now - ( 60 * 60 * 48 );
 const region = 'us-east-1';
 const group = '/aws/lambda/hm-linter';
 const query = `fields @message | sort @timestamp asc | filter @requestId = '${ reqId }'`;

--- a/scripts/get-logs.js
+++ b/scripts/get-logs.js
@@ -9,7 +9,7 @@ const start = now - ( 60 * 60 * HOUR_LIMIT );
 const region = 'us-east-1';
 const group = '/aws/lambda/hm-linter';
 const query = `fields @message | sort @timestamp asc | filter @requestId = '${ reqId }'`;
-
+const logDir = './logs';
 
 process.stderr.write( `Querying for ${ reqId }\n` );
 const proc = child_process.spawnSync(
@@ -41,7 +41,7 @@ const dataRegex = /^.+?\t.+?\t(\{.+)/s;
 
 process.stderr.write( 'Waiting for results…\n' );
 setTimeout( function () {
-	const logFile = fs.openSync( `./${ reqId }.log`, 'w' );
+	const logFile = fs.openSync( `${ logDir }/${ reqId }.log`, 'w' );
 	const viewProc = child_process.spawnSync(
 		'aws',
 		[
@@ -75,7 +75,7 @@ setTimeout( function () {
 	} );
 
 	fs.closeSync( logFile );
-	fs.writeFileSync( `./${ reqId }.json`, rawData );
-	process.stderr.write( `Log saved to:\t\t${ reqId }.log\n` );
-	process.stderr.write( `Raw data saved to:\t${ reqId }.json\n` );
+	fs.writeFileSync( `${ logDir }/${ reqId }.json`, rawData );
+	process.stderr.write( `Log saved to:\t\tlogs/${ reqId }.log\n` );
+	process.stderr.write( `Raw data saved to:\tlogs/${ reqId }.json\n` );
 }, 2000 );


### PR DESCRIPTION
Adds a brand new `scripts/get-logs.js` which fetches the logs for a given request ID, and extracts the raw data to make it easier to test locally.

Note: the request has to be less than two hours old for this, as the query is time-limited.