### PR TITLE
Use DealerDirect installed_paths where available

### DIFF
--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -53,23 +53,20 @@ module.exports = standardPath => codepath => {
 	} ) ).then( rulesetFiles => {
 		const standard = rulesetFiles.find( file => !! file ) || `vendor/humanmade/coding-standards`;
 
-		let installed_paths = 'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer,vendor/humanmade/coding-standards/HM';
-
-		// Only include the VIP WPCS if the path exists within this version of the standards.
-		if ( fs.existsSync( path.join( standardPath, 'vendor', 'automattic', 'vipwpcs' ) ) ) {
-			installed_paths += ',vendor/automattic/vipwpcs';
-		}
+		// Only include installed_paths where DealerDirect hasn't handled them for us.
+		const needInstalledPaths = ( ! fs.existsSync( path.join( standardPath, 'vendor', 'dealerdirect' ) ) );
 
 		// const standard = 'PSR2'; //...
 		const args = [
 			phpcsPath,
 			'--runtime-set',
-			'installed_paths',
-			installed_paths,
+			needInstalledPaths ? 'installed_paths' : '',
+			needInstalledPaths ? 'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer,vendor/humanmade/coding-standards/HM' : '',
 			`--standard=${standard}`,
 			'--report=json',
 			codepath
 		];
+
 		const opts = {
 			cwd: standardPath,
 			env: process.env,


### PR DESCRIPTION
This PR fixes #97 by using the existence of the DealerDirect dependency to decide whether or not we should pass an installed_paths argument at all. 

I wanted to use the recommended `args.push` method, but PHPCS very much wanted a specific order on the arguments and the file list to be last. Pushing several arguments in felt like a worse solution than this but I'm very much open to better ideas 😃