### PR TITLE
Add extra configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,13 @@ Deployment can be done in one step by running the `deploy` script, but you shoul
 * `test` - Run the index handler against a simulated Lambda environment. Before running this:
 	* Run `build` at least once
 	* Set the `AWS_LAMBDA_EVENT_BODY` environment variable to the contents of `fixtures/lambda-test-event.json` (`cat fixtures/lambda-test-event.json | read -z AWS_LAMBDA_EVENT_BODY`)
+
+
+## Advanced Configuration
+
+Deployment settings can be changed using environment variables. In addition to the app settings noted above, the following can also be set:
+
+* `CONFIG_FILE` - Name of the configuration file (default `hmlinter.yml`)
+* `STANDARD_URL` - URL for the standards directory (default `https://make.hmn.md/hmlinter/standards`)
+* `DEFAULT_STANDARD_PHPCS` - Default standard to check against for phpcs (default `vendor/humanmade/coding-standards`)
+* `DEFAULT_STANDARD_ESLINT` - Default standard to check against for ESLint (default `eslint-config-humanmade`)

--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,7 @@ const DEFAULT_CONFIG = {
 		version: 'inherit',
 	},
 };
-const FILENAME = 'hmlinter.yml';
+const FILENAME = process.env.CONFIG_FILE || 'hmlinter.yml';
 
 module.exports = async context => {
 	return await context.config( FILENAME, DEFAULT_CONFIG );

--- a/src/linters/eslint/index.js
+++ b/src/linters/eslint/index.js
@@ -63,6 +63,8 @@ const run = ( engine, codepath ) => {
 	}
 };
 
+const DEFAULT_STANDARD = process.env.DEFAULT_STANDARD_ESLINT || 'eslint-config-humanmade';
+
 module.exports = standardPath => codepath => {
 	const options = {
 		cwd: codepath,
@@ -75,13 +77,13 @@ module.exports = standardPath => codepath => {
 	// This ensures dependencies load from the standards instead, and the
 	// standard itself is loaded from the right place.
 	moduleAlias.addPath( `${ standardPath }/node_modules` );
-	moduleAlias.addAlias( 'eslint-config-humanmade', standardPath );
+	moduleAlias.addAlias( DEFAULT_STANDARD, standardPath );
 
-	const actualStandardPath = require.resolve( 'eslint-config-humanmade' );
+	const actualStandardPath = require.resolve( DEFAULT_STANDARD );
 	const origFindPath = Module._findPath;
 	Module._findPath = ( name, ...args ) => {
 		const path = origFindPath( name, ...args );
-		if ( ! path && name === 'eslint-config-humanmade' ) {
+		if ( ! path && name === DEFAULT_STANDARD ) {
 			return actualStandardPath;
 		}
 		return path;

--- a/src/linters/index.js
+++ b/src/linters/index.js
@@ -9,7 +9,7 @@ const available = {
 };
 
 const STANDARDS_DIR = '/tmp/hmlinter-standards';
-const BASE_URL = 'https://make.hmn.md/hmlinter/standards';
+const BASE_URL = process.env.STANDARD_URL || 'https://make.hmn.md/hmlinter/standards';
 
 const httpGet = ( ...args ) => {
 	return new Promise( ( resolve, reject ) => {

--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -51,7 +51,7 @@ module.exports = standardPath => codepath => {
 			} );
 		} );
 	} ) ).then( rulesetFiles => {
-		const standard = rulesetFiles.find( file => !! file ) || `vendor/humanmade/coding-standards`;
+		const standard = rulesetFiles.find( file => !! file ) || process.env.DEFAULT_STANDARD_PHPCS || 'vendor/humanmade/coding-standards';
 
 		let installed_paths = 'vendor/wp-coding-standards/wpcs,vendor/fig-r/psr2r-sniffer,vendor/humanmade/coding-standards/HM';
 


### PR DESCRIPTION
This allows more of hm-linter's behaviour to be changed at the deployment level, making it more useful for deployment by other companies or for other uses internally.

Needs testing.