### PR TITLE
Allow alternative deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,5 @@ Deployment settings can be changed using environment variables. In addition to t
 * `STANDARD_URL` - URL for the standards directory (default `https://make.hmn.md/hmlinter/standards`)
 * `DEFAULT_STANDARD_PHPCS` - Default standard to check against for phpcs (default `vendor/humanmade/coding-standards`)
 * `DEFAULT_STANDARD_ESLINT` - Default standard to check against for ESLint (default `eslint-config-humanmade`)
+* `LAMBDA_FUNCTION` - Lambda function name for the `deploy` command (default `hmlinter`)
+* `LAMBDA_REGION` - Lambda function region for the `deploy` command (default `us-east-1`)

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Deployment can be done in one step by running the `deploy` script, but you shoul
 
 Deployment settings can be changed using environment variables. In addition to the app settings noted above, the following can also be set:
 
+* `BOT_NAME` - Name of the bot (default `hmlinter`)
 * `CONFIG_FILE` - Name of the configuration file (default `hmlinter.yml`)
 * `STANDARD_URL` - URL for the standards directory (default `https://make.hmn.md/hmlinter/standards`)
 * `DEFAULT_STANDARD_PHPCS` - Default standard to check against for phpcs (default `vendor/humanmade/coding-standards`)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "deploy": "npm run clean:package && npm run build && npm run deploy:check && npm run deploy:package-production && npm run deploy:push",
     "deploy:dev": "npm run clean:package && npm run build && npm run deploy:check-dev && npm run deploy:package-dev && npm run deploy:push-dev",
     "start": "node start-development.js",
-    "test": "docker run -e \"APP_ID=5455\" -e \"WEBHOOK_SECRET=development\" -v \"$PWD\":/var/task lambci/lambda:nodejs8.10 index.probotHandler \"$AWS_LAMBDA_EVENT_BODY\""
+    "test": "docker run --env-file .env -v \"$PWD\":/var/task lambci/lambda:nodejs12.x index.probotHandler \"$AWS_LAMBDA_EVENT_BODY\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "babel-polyfill": "6.16.0",
     "babel-preset-es2015": "6.16.0",
     "babel-preset-stage-0": "6.16.0",
-    "dotenv": "^5.0.1"
+    "dotenv": "^5.0.1",
+    "run.env": "^1.1.0"
   },
   "scripts": {
     "build:babel": "( rm -rf build || true ) && mkdir build && babel src --out-dir build --ignore src/linters/phpcs/vendor -D",
@@ -33,8 +34,8 @@
     "deploy:package": "zip --symlinks -9 -x lambda-function.zip -x \"src/*\" -r lambda-function *",
     "deploy:package-dev": "npm run deploy:package && cp development.private-key.pem private-key.pem && zip -9 lambda-function private-key.pem",
     "deploy:package-production": "npm run deploy:package && cp production.private-key.pem private-key.pem && zip -9 lambda-function private-key.pem",
-    "deploy:push": "aws lambda update-function-code --function-name hm-linter --region us-east-1 --zip-file fileb://lambda-function.zip",
-    "deploy:push-dev": "aws lambda update-function-code --function-name hm-linter-development --region us-east-1 --zip-file fileb://lambda-function.zip",
+    "deploy:push": "NODE_ENV=production run.env scripts/deploy.sh",
+    "deploy:push-dev": "NODE_ENV=development run.env scripts/deploy.sh",
     "deploy": "npm run clean:package && npm run build && npm run deploy:check && npm run deploy:package-production && npm run deploy:push",
     "deploy:dev": "npm run clean:package && npm run build && npm run deploy:check-dev && npm run deploy:package-dev && npm run deploy:push-dev",
     "start": "node start-development.js",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+if [[ -z "$LAMBDA_FUNCTION" ]]; then
+	echo "LAMBDA_FUNCTION must be set in .env"
+	exit 1
+fi
+
+: "${LAMBDA_REGION:=us-east-1}"
+
+echo "Deploying to $LAMBDA_FUNCTION in $LAMBDA_REGION"
+aws lambda update-function-code --function-name $LAMBDA_FUNCTION --region $LAMBDA_REGION --zip-file fileb://lambda-function.zip

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -49,7 +49,7 @@ const onAdd = async context => {
 		github.issues.create( {
 			owner,
 			repo: repo.name,
-			title: `Hello from hm-linter! (${ summary })`,
+			title: `Hello from ${ process.env.BOT_NAME || 'hmlinter' }! (${ summary })`,
 			body,
 		} );
 	} );
@@ -73,7 +73,7 @@ const onPush = async context => {
 			owner,
 			repo,
 			sha:     commit,
-			context: 'hmlinter',
+			context: process.env.BOT_NAME || 'hmlinter',
 			state,
 			description: description.substr( 0,139 ),
 			target_url: logUrl,
@@ -133,7 +133,7 @@ const onCheck = async context => {
 			accept: 'application/vnd.github.antiope-preview+json',
 		},
 		input: {
-			name: 'hmlinter',
+			name: process.env.BOT_NAME || 'hmlinter',
 			head_branch,
 			head_sha,
 			started_at: ( new Date() ).toISOString(),
@@ -192,7 +192,7 @@ const onCheck = async context => {
 		completeRun(
 			'failure',
 			{
-				title: 'Failed to run hmlinter',
+				title: `Failed to run ${ process.env.BOT_NAME || 'hmlinter' }`,
 				summary: `Could not run: ${ e }`,
 				output: JSON.stringify( serializeError( e ), null, 2 )
 			}
@@ -225,7 +225,7 @@ const onCheck = async context => {
 		completeRun(
 			'failure',
 			{
-				title: 'hmlinter checks failed',
+				title: `${ process.env.BOT_NAME || 'hmlinter' } checks failed`,
 				summary: formatSummary( lintState ),
 				annotations: lastGroup,
 			}


### PR DESCRIPTION
We have a few built-in assumptions right now around names. This allows reconfiguring it, specifically for the deployment steps. In the process, it makes it a bit cleaner.