### PR TITLE
Calculate phpcs totals manually

### DIFF
--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -25,15 +25,22 @@ const formatMessage = message => {
 
 const formatOutput = ( data, codepath ) => {
 	const totals = {
-		errors:   data.totals.errors,
-		warnings: data.totals.warnings,
+		errors: 0,
+		warnings: 0,
 	};
 	const files = {};
 	Object.keys( data.files ).forEach( file => {
 		// Ensure the path has a leading slash.
 		const fullPath = file.replace( /^([^\/])/,'/$1' );
 		const relPath = path.relative( codepath, fullPath );
-		files[ relPath ] = data.files[ file ].messages.map( formatMessage );
+		const messages = data.files[ file ].messages.map( formatMessage );
+		totals.errors = messages.reduce( ( count, message ) => {
+			return message.severity === 'error' ? count + 1 : count;
+		}, totals.errors );
+		totals.warnings = messages.reduce( ( count, message ) => {
+			return message.severity === 'warning' ? count + 1 : count;
+		}, totals.warnings );
+		files[ relPath ] = messages;
 	} );
 
 	return { totals, files };


### PR DESCRIPTION
phpcs appears to sometimes return the wrong totals for each type, so this uses our internally-calculated type from the preparation step instead.

The main issue here is that if there's no errors, annotations won't be added at all; overriding this means we're now correctly treating warnings as errors (as originally intended; see #29) so any issues that are flagged will correctly be added as annotations now.