### PR TITLE
Add FORCE_NEUTRAL_STATUS configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,4 @@ Deployment settings can be changed using environment variables. In addition to t
 * `DEFAULT_STANDARD_ESLINT` - Default standard to check against for ESLint (default `eslint-config-humanmade`)
 * `LAMBDA_FUNCTION` - Lambda function name for the `deploy` command (default `hmlinter`)
 * `LAMBDA_REGION` - Lambda function region for the `deploy` command (default `us-east-1`)
+* `FORCE_NEUTRAL_STATUS` - Mark failed checks as "neutral", which shows the check but does not mark it as failed (default disabled)


### PR DESCRIPTION
This adds the ability to run checks without having them mark PRs as failing, allowing gradual adoption of hm-linter, or usage on legacy repos.

Open question: should this change failure/error -> neutral, or should it also change success -> neutral as it currently does?