### PR TITLE
Only set installed_paths if there's no default

### DIFF
--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -65,31 +65,40 @@ module.exports = standardPath => codepath => {
 			standard = rulesetFiles.find( file => !! file ) || process.env.DEFAULT_STANDARD_PHPCS || 'vendor/humanmade/coding-standards';
 		}
 
-		const installedPaths = [
-			'vendor/fig-r/psr2r-sniffer',
-			'vendor/humanmade/coding-standards/HM',
-			'vendor/humanmade/coding-standards/HM-Required',
-			'vendor/phpcompatibility/php-compatibility',
-			'vendor/phpcompatibility/phpcompatibility-paragonie',
-			'vendor/phpcompatibility/phpcompatibility-wp',
-			'vendor/wp-coding-standards/wpcs',
-		]
-
-		// Only include the VIP WPCS if the path exists within this version of the standards.
-		if ( fs.existsSync( path.join( standardPath, 'vendor', 'automattic', 'vipwpcs' ) ) ) {
-			installedPaths.push( 'vendor/automattic/vipwpcs' );
-		}
-
-		// const standard = 'PSR2'; //...
+		// Set the main options.
 		const args = [
 			phpcsPath,
-			'--runtime-set',
-			'installed_paths',
-			installedPaths.join( ',' ),
 			`--standard=${standard}`,
 			'--report=json',
-			codepath
 		];
+
+		// If dealerdirect/phpcodesniffer-composer-installer wasn't installed,
+		// the configuration file won't exist.
+		if ( ! fs.existsSync( path.join( standardPath, 'vendor', 'squizlabs', 'php_codesniffer', 'CodeSniffer.conf' ) ) ) {
+			const installedPaths = [
+				'vendor/fig-r/psr2r-sniffer',
+				'vendor/humanmade/coding-standards/HM',
+				'vendor/humanmade/coding-standards/HM-Required',
+				'vendor/phpcompatibility/php-compatibility',
+				'vendor/phpcompatibility/phpcompatibility-paragonie',
+				'vendor/phpcompatibility/phpcompatibility-wp',
+				'vendor/wp-coding-standards/wpcs',
+			]
+
+			// Only include the VIP WPCS if the path exists within this version of the standards.
+			if ( fs.existsSync( path.join( standardPath, 'vendor', 'automattic', 'vipwpcs' ) ) ) {
+				installedPaths.push( 'vendor/automattic/vipwpcs' );
+			}
+
+			// Add the installed paths to the CLI.
+			args.push(
+				'--runtime-set',
+				'installed_paths',
+				installedPaths.join( ',' ),
+			);
+		}
+
+		// Finally, add codepath.
 		const opts = {
 			cwd: standardPath,
 			env: process.env,

--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -98,7 +98,6 @@ module.exports = standardPath => codepath => {
 			);
 		}
 
-		// Finally, add codepath.
 		const opts = {
 			cwd: standardPath,
 			env: process.env,


### PR DESCRIPTION
Obsoletes #108. Fixes #97.

This checks for the presence of phpcs' internal configuration file (i.e. the one use for `--config-set`/etc) at `vendor/squizlabs/php_codesniffer/CodeSniffer.conf`. When `dealerdirect/phpcodesniffer-composer-installer` is required, it runs `phpcs --config-set installed_paths ...` after any package is added or removed. This creates the config file.

Installed paths are now only set manually if there's no configuration, allowing us to bundle this properly into the standard instead.