### PR TITLE
Add Stylelint

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ phpcs:
 eslint:
     enabled: true
     version: inherit
+
+stylelint:
+    enabled: false
+    version: inherit
 ```
 
 Versions **MUST** be specified in full format (i.e. `0.5.0`). `latest` is available as a convenient shorthand for the latest published version, but note that this will be updated and may cause your code to fail future checks.

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,10 @@ const DEFAULT_CONFIG = {
 		enabled: true,
 		version: 'inherit',
 	},
+	stylelint: {
+		enabled: false,
+		version: 'inherit',
+	},
 };
 const FILENAME = 'hmlinter.yml';
 

--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,7 @@ const DEFAULT_CONFIG = {
 		version: 'inherit',
 	},
 	stylelint: {
-		enabled: true,
+		enabled: false,
 		version: 'inherit',
 	},
 };

--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,7 @@ const DEFAULT_CONFIG = {
 		version: 'inherit',
 	},
 	stylelint: {
-		enabled: false,
+		enabled: true,
 		version: 'inherit',
 	},
 };

--- a/src/linters/index.js
+++ b/src/linters/index.js
@@ -6,6 +6,7 @@ const tar = require( 'tar' );
 const available = {
 	eslint: require( './eslint' ),
 	phpcs: require( './phpcs' ),
+	stylelint: require( './stylelint' ),
 };
 
 const STANDARDS_DIR = '/tmp/hmlinter-standards';

--- a/src/linters/index.js
+++ b/src/linters/index.js
@@ -8,7 +8,7 @@ const available = {
 	phpcs: require( './phpcs' ),
 	stylelint: require( './stylelint' ),
 };
-const enabled = ( process.env.ENABLED_LINTERS || 'eslint,phpcs' ).split( ',' );
+const enabled = ( process.env.ENABLED_LINTERS || 'eslint,phpcs,stylelint' ).split( ',' );
 
 const STANDARDS_DIR = '/tmp/hmlinter-standards';
 const BASE_URL = process.env.STANDARD_URL || 'https://make.hmn.md/hmlinter/standards';

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -1,4 +1,3 @@
-const fs = require( 'fs' );
 const Module = require( 'module' );
 const path = require( 'path' );
 const moduleAlias = require( 'module-alias' );
@@ -6,7 +5,7 @@ const moduleAlias = require( 'module-alias' );
 /**
  * Convert an error message from the stylelint format into one acceptable for GitHub
  *
- * @param {Object} message
+ * @param {Object} message Data about a warning from stylelint.
  * @returns {Object}
  */
 const formatMessage = message => ( {
@@ -20,11 +19,12 @@ const formatMessage = message => ( {
 /**
  * Fetch a count of the total errors and warnings for our response.
  *
- * @param {Object} files
+ * @param {Object} files Formatted warnings against specific files.
  * @returns {{warnings: number, errors: number}}
  */
 const getTotals = ( files ) => {
-	const allErrors = Object.keys(files).reduce( ( accumulator, key ) => accumulator.concat( [ ...files[key] ] ), [] );
+	const allErrors = Object.keys( files )
+		.reduce( ( accumulator, key ) => accumulator.concat( [ ...files[key] ] ), [] );
 
 	return {
 		errors:   allErrors.filter( errorData => errorData.severity === 'error' ).length,
@@ -35,8 +35,8 @@ const getTotals = ( files ) => {
 /**
  * Properly Format the return for GitHub.
  *
- * @param {Object} data
- * @param {string} codepath
+ * @param {Object} data Raw data from stylelint Node runner.
+ * @param {String} codepath Path against which to check files.
  * @returns {{files: {}, totals: {warnings: number, errors: number}}}
  */
 const formatOutput = ( data, codepath ) => {
@@ -59,6 +59,12 @@ const formatOutput = ( data, codepath ) => {
 	return { totals: getTotals( files ), files };
 };
 
+/**
+ * Run stylelint checks.
+ *
+ * @param {String} standardPath Path against which to check files.
+ * @returns {() => Promise}
+ */
 module.exports = standardPath => codepath => {
 	const options = {
 		files: codepath,
@@ -85,7 +91,7 @@ module.exports = standardPath => codepath => {
 
 	const { lint } = require( '@runner-packages/stylelint' );
 
-	return new Promise( ( resolve, reject ) => {
+	return new Promise( resolve => {
 		let data;
 
 		try {

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -23,7 +23,7 @@ const formatMessage = message => ( {
  * @returns {{warnings: number, errors: number}}
  */
 const getTotals = ( files ) => {
-	const allErrors = Object.keys( files ).reduce( ( acc, key ) => [ ...acc, ...files[key] ], [] );
+	const allErrors = Object.keys( files ).reduce( ( acc, key ) => [ ...acc, ...files[ key ] ], [] );
 
 	return {
 		errors: allErrors.filter( errorData => errorData.severity === 'error' ).length,

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -23,8 +23,7 @@ const formatMessage = message => ( {
  * @returns {{warnings: number, errors: number}}
  */
 const getTotals = ( files ) => {
-	const allErrors = Object.keys( files )
-		.reduce( ( accumulator, key ) => accumulator.concat( [ ...files[key] ] ), [] );
+	const allErrors = Object.keys( files ).reduce( ( acc, key ) => [ ...acc, ...files[key] ], [] );
 
 	return {
 		errors: allErrors.filter( errorData => errorData.severity === 'error' ).length,

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -101,7 +101,7 @@ module.exports = standardPath => codepath => {
 			throw err;
 		}
 
-		const output = data.then(resultObject => formatOutput( resultObject, codepath ));
+		const output = data.then( resultObject => formatOutput( resultObject, codepath ) );
 
 		// Reset path loader.
 		moduleAlias.reset();

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -9,11 +9,11 @@ const moduleAlias = require( 'module-alias' );
  * @returns {Object}
  */
 const formatMessage = message => ( {
-	line:     message.line,
-	column:   message.column,
+	line: message.line,
+	column: message.column,
 	severity: message.severity,
-	message:  message.text,
-	source:   message.rule,
+	message: message.text,
+	source: message.rule,
 } );
 
 /**
@@ -27,7 +27,7 @@ const getTotals = ( files ) => {
 		.reduce( ( accumulator, key ) => accumulator.concat( [ ...files[key] ] ), [] );
 
 	return {
-		errors:   allErrors.filter( errorData => errorData.severity === 'error' ).length,
+		errors: allErrors.filter( errorData => errorData.severity === 'error' ).length,
 		warnings: allErrors.filter( errorData => errorData.severity === 'warning' ).length,
 	};
 };

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -55,7 +55,10 @@ const formatOutput = ( data, codepath ) => {
 		files[ relPath ] = result.warnings.map( formatMessage );
 	} );
 
-	return { totals: getTotals( files ), files };
+	return {
+		totals: getTotals( files ),
+		files,
+	};
 };
 
 /**

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -48,12 +48,12 @@ const formatOutput = ( data, codepath ) => {
 		}
 
 		// Exclude any empty files.
-		if ( ! result._postcssResult.messages.length ) {
+		if ( ! result.warnings.length ) {
 			return;
 		}
 
 		const relPath = path.relative( codepath, result.source );
-		files[ relPath ] = result._postcssResult.messages.map( formatMessage );
+		files[ relPath ] = result.warnings.map( formatMessage );
 	} );
 
 	return { totals: getTotals( files ), files };

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -1,0 +1,92 @@
+const fs = require( 'fs' );
+const Module = require( 'module' );
+const path = require( 'path' );
+const moduleAlias = require( 'module-alias' );
+
+const formatMessage = message => {
+	console.log( message );
+
+	return {
+		line:     message.line,
+		column:   message.column,
+		severity: message.severity >= 2 ? 'error' : 'warning',
+		message:  message.message,
+		source:   message.ruleId,
+	};
+};
+
+const formatOutput = ( data, codepath ) => {
+	const totals = {
+		errors:   data.errorCount,
+		warnings: data.warningCount,
+	};
+	const files = {};
+	// console.log( data );
+	data.results.forEach( result => {
+		// Exclude any empty files.
+		if ( ! result.messages.length ) {
+			return;
+		}
+
+		const relPath = path.relative( codepath, result.filePath );
+		files[ relPath ] = result.messages.map( formatMessage );
+	} );
+
+	return { totals, files };
+};
+
+module.exports = standardPath => codepath => {
+	const options = {
+		cwd: codepath,
+	};
+
+	console.log( standardPath );
+	console.log( `${ standardPath }node_modules` );
+
+	// We need to use node_modules from the standard directory, but because
+	// we're not invoking eslint over the CLI, we can't change where `require()`
+	// loads modules from unless we override the module loader.
+	//
+	// This ensures dependencies load from the standards instead, and the
+	// standard itself is loaded from the right place.
+	moduleAlias.addPath( `${ standardPath }node_modules` );
+	moduleAlias.addAlias( '@humanmade/stylelint-config', standardPath );
+
+	const actualStandardPath = require.resolve( '@humanmade/stylelint-config' );
+	const origFindPath = Module._findPath;
+	Module._findPath = ( name, ...args ) => {
+		const path = origFindPath( name, ...args );
+		if ( ! path && name === '@humanmade/stylelint-config' ) {
+			return actualStandardPath;
+		}
+		return path;
+	};
+
+	const { CLIEngine } = require( 'stylelint' );
+	const engine = new CLIEngine( options );
+
+	return new Promise( ( resolve, reject ) => {
+		let output;
+		try {
+			output = run( engine, codepath );
+		} catch ( err ) {
+			if ( err.messageTemplate === 'no-config-found' ) {
+				// Try with default configuration.
+				const engine = new CLIEngine( { ...options, configFile: `${ standardPath }/.stylelintrc.json` } );
+				console.log( 'Running stylelint with default config on path', codepath );
+				output = run( engine, codepath );
+			} else {
+				console.log( err );
+				throw err;
+			}
+		}
+
+		// Reset path loader.
+		moduleAlias.reset();
+		Module._findPath = origFindPath;
+
+		console.log( output );
+
+		resolve( formatOutput( output, codepath ) );
+	} );
+};

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -1,6 +1,6 @@
 const Module = require( 'module' );
-const path = require( 'path' );
 const moduleAlias = require( 'module-alias' );
+const path = require( 'path' );
 
 /**
  * Convert an error message from the stylelint format into one acceptable for GitHub


### PR DESCRIPTION
This PR adds the ability to run our stylelint standards in the Linter Bot.

To test:
 - Turn on Stylelint in the config and pass the config straight through instead of obeying the repo's for testing purposes. Alternatively, modify the `master` `hmlinter.yml` in `linter-bot-test`.
 - Run the bot locally against https://github.com/humanmade/linter-bot-test/pull/8

Resolves #80