### PR TITLE
Allow for custom Stylelint configuration

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -196,6 +196,11 @@ const formatAnnotations = ( state, baseUrl ) => {
 const formatMetadata = context => {
 	const { metadata, reqContext } = context;
 
+	// Short-circuit for `yarn start` requests which don't have the additional context needed.
+	if ( ! metadata || ! reqContext ) {
+		return '';
+	}
+
 	let body = '<details><summary>Request details</summary><ul>';
 	body += `\n<li><strong>GitHub Event ID:</strong> <code>${ metadata.headers['X-GitHub-Delivery'] }</code></li>`;
 	body += `\n<li><strong>API Gateway ID:</strong> <code>${ metadata.requestContext.requestId }</code></li>`;

--- a/src/format.js
+++ b/src/format.js
@@ -196,11 +196,6 @@ const formatAnnotations = ( state, baseUrl ) => {
 const formatMetadata = context => {
 	const { metadata, reqContext } = context;
 
-	// Short-circuit for `yarn start` requests which don't have the additional context needed.
-	if ( ! metadata || ! reqContext ) {
-		return '';
-	}
-
 	let body = '<details><summary>Request details</summary><ul>';
 	body += `\n<li><strong>GitHub Event ID:</strong> <code>${ metadata.headers['X-GitHub-Delivery'] }</code></li>`;
 	body += `\n<li><strong>API Gateway ID:</strong> <code>${ metadata.requestContext.requestId }</code></li>`;

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -82,10 +82,7 @@ const formatOutput = ( data, codepath ) => {
  */
 module.exports = standardPath => codepath => {
 	const options = {
-		files: [
-			`${ codepath }/**/*.css`,
-			`${ codepath }/**/*.scss`,
-		],
+		files: codepath,
 		configBasedir: `${ standardPath }node_modules`,
 		// Force a count of all warnings and errors from the Node return.
 		maxWarnings: 0,

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -1,5 +1,6 @@
 const fs = require( 'fs' );
 const Module = require( 'module' );
+const process = require( 'process' );
 const moduleAlias = require( 'module-alias' );
 const path = require( 'path' );
 
@@ -98,12 +99,21 @@ module.exports = standardPath => codepath => {
 
 	const { lint } = require( '@runner-packages/stylelint' );
 
+	const oldCwd = process.cwd();
+	try {
+		process.chdir( codepath );
+		console.log( '----- Cwd', process.cwd() );
+	} catch {
+		console.log( '----- Directory change failed' );
+	}
+
 	return new Promise( resolve => {
 		let output;
 
 		output = lint( options )
 			.then( resultObject => formatOutput( resultObject, codepath ) )
 			.catch( error => {
+
 				// code 78 is a configuration not found, which means we can't access @humanmade/stylelint-config.
 				// Run with our default configuration; most projects only use this anyway.
 				if ( error.code === 78 ) {
@@ -119,6 +129,7 @@ module.exports = standardPath => codepath => {
 
 		// Reset path loader.
 		moduleAlias.reset();
+		process.chdir( oldCwd );
 
 		resolve( output );
 	} );

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -1,5 +1,4 @@
 const fs = require( 'fs' );
-const Module = require( 'module' );
 const process = require( 'process' );
 const moduleAlias = require( 'module-alias' );
 const path = require( 'path' );
@@ -78,7 +77,7 @@ const formatOutput = ( data, codepath ) => {
  * @param {String} standardPath Path against which to check files.
  * @returns {() => Promise}
  */
-module.exports = async standardPath => async codepath => {
+module.exports = standardPath => codepath => {
 	const options = {
 		files: [
 			`${ codepath }/**/*.css`,
@@ -118,16 +117,19 @@ module.exports = async standardPath => async codepath => {
 				return formatOutput( resultObject, codepath );
 			} )
 			.catch( error => {
-				process.chdir( oldCwd );
-
 				// code 78 is a configuration not found, which means we can't access @humanmade/stylelint-config.
 				// Run with our default configuration; most projects only use this anyway.
 				if ( error.code === 78 ) {
 					console.log( 'Running stylelint with default config on path', codepath );
 
-					return lint( { ...options, configFile: `${ standardPath }/.stylelintrc.json` } )
+					const results = lint( { ...options, configFile: `${ standardPath }/.stylelintrc.json` } )
 						.then( resultObject => formatOutput( resultObject, codepath ) );
+
+					process.chdir( oldCwd );
+
+					return results;
 				} else {
+					process.chdir( oldCwd );
 					console.log( error );
 					throw error;
 				}

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -105,14 +105,14 @@ module.exports = standardPath => codepath => {
 			.then( resultObject => formatOutput( resultObject, codepath ) )
 			.catch( error => {
 				// code 78 is a configuration not found, which means we can't access @humanmade/stylelint-config.
-				// Run with our default configuration; most project only use this anyway.
+				// Run with our default configuration; most projects only use this anyway.
 				if ( error.code === 78 ) {
 					console.log( 'Running stylelint with default config on path', codepath );
 
 					return lint( { ...options, configFile: `${ standardPath }/.stylelintrc.json` } )
 						.then( resultObject => formatOutput( resultObject, codepath ) );
 				} else {
-					console.log(error);
+					console.log( error );
 					throw error;
 				}
 			} );

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -41,6 +41,15 @@ const getTotals = ( files ) => {
  */
 const formatOutput = ( data, codepath ) => {
 	const files = {};
+
+	// There were no errors, simply bounce.
+	if ( ! data.errored ) {
+		return {
+			totals: 0,
+			files: [],
+		};
+	}
+
 	data.results.forEach( result => {
 		// Only parse through CSS or SCSS files.
 		if ( ! result.source.match( /\.s?css$/ ) ) {

--- a/src/linters/stylelint/index.js
+++ b/src/linters/stylelint/index.js
@@ -43,9 +43,12 @@ const formatOutput = ( data, codepath ) => {
 	const files = {};
 
 	// There were no errors, simply bounce.
-	if ( ! data.errored ) {
+	if ( ! data.maxWarningsExceeded || data.maxWarningsExceeded.foundWarnings.length < 1 ) {
 		return {
-			totals: 0,
+			totals: {
+				errors: 0,
+				warnings: 0,
+			},
 			files: [],
 		};
 	}
@@ -84,6 +87,8 @@ module.exports = standardPath => codepath => {
 			`${ codepath }/**/*.scss`,
 		],
 		configBasedir: `${ standardPath }node_modules`,
+		// Force a count of all warnings and errors from the Node return.
+		maxWarnings: 0,
 	};
 
 	// stylelint use `resolve-from` internally which looks at specific directories only for configs.


### PR DESCRIPTION
In the previous PR, I erroneously assumed that we'd just be using the default `.stylelintrc.json` file that ships with our config, completely forgetting that some projects use custom configurations. This PR allows using custom configurations within project files.