### PR TITLE
Only mark "passed" when there are no warnings either

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -45,5 +45,9 @@ module.exports = async ( pushConfig, config, github, allowReuse = false ) => {
 		return totals;
 	}, { errors: 0, warnings: 0 } );
 
-	return { totals, passed: totals.errors === 0, results };
+	return {
+		passed: totals.errors === 0 && totals.warnings === 0,
+		totals,
+		results,
+	};
 };


### PR DESCRIPTION
Per discussion in Slack, @rmccue would like LinterBot to log out warnings, too: this should do that, albeit in a naive way.