### PR TITLE
Read configuration from HEAD

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -41,7 +41,7 @@ module.exports = async ( context, head ) => {
 		const res = await context.github.repos.getContent( params );
 		const config = yaml.safeLoad( Buffer.from( res.data.content, 'base64' ).toString() ) || {};
 		return {
-			...defaultConfig,
+			...DEFAULT_CONFIG,
 			...config
 		};
 	} catch ( err ) {

--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,6 @@ module.exports = async ( context, head ) => {
 	const params = {
 		...context.repo( {
 			path: path.posix.join( '.github', FILENAME ),
-			foo: 'bar',
 		} ),
 		ref: head,
 	};

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,6 @@
+const yaml = require( 'js-yaml' );
+const path = require( 'path' );
+
 const DEFAULT_CONFIG = {
 	version: 'latest',
 	phpcs: {
@@ -15,6 +18,37 @@ const DEFAULT_CONFIG = {
 };
 const FILENAME = process.env.CONFIG_FILE || 'hmlinter.yml';
 
-module.exports = async context => {
-	return await context.config( FILENAME, DEFAULT_CONFIG );
+/**
+ * Reads the app configuration from the given YAML file in the `.github`
+ * directory of the repository.
+ *
+ * @internal Ported from probot, but adapted to read from the current branch.
+ *
+ * @param context Context from Probot
+ * @param head SHA of the head commit we're running against.
+ * @return Configuration object read from the file
+ */
+module.exports = async ( context, head ) => {
+	const params = {
+		...context.repo( {
+			path: path.posix.join( '.github', FILENAME ),
+			foo: 'bar',
+		} ),
+		ref: head,
+	};
+
+	try {
+		const res = await context.github.repos.getContent( params );
+		const config = yaml.safeLoad( Buffer.from( res.data.content, 'base64' ).toString() ) || {};
+		return {
+			...defaultConfig,
+			...config
+		};
+	} catch ( err ) {
+		if ( err.code === 404 ) {
+			return DEFAULT_CONFIG;
+		} else {
+			throw err;
+		}
+	}
 };

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -32,7 +32,7 @@ const onAdd = async context => {
 		};
 		let lintState;
 		try {
-			lintState = await runForRepo( pushConfig, getConfig( context ), github );
+			lintState = await runForRepo( pushConfig, getConfig( context, branch.data.commit.sha ), github );
 		} catch ( e ) {
 			console.log( e );
 			throw e;
@@ -86,7 +86,7 @@ const onPush = async context => {
 	let lintState;
 	let logUrl = '';
 	try {
-		lintState = await runForRepo( pushConfig, getConfig( context ), github );
+		lintState = await runForRepo( pushConfig, getConfig( context, commit ), github );
 	} catch ( e ) {
 		console.log(e)
 		logUrl = await createGist(
@@ -186,7 +186,7 @@ const onCheck = async context => {
 	const pushConfig = { commit: head_sha, owner, repo };
 	let lintState;
 	try {
-		lintState = await runForRepo( pushConfig, getConfig( context ), github );
+		lintState = await runForRepo( pushConfig, getConfig( context, head_sha ), github );
 	} catch ( e ) {
 		console.log(e)
 		completeRun(
@@ -279,7 +279,7 @@ const onOpenPull = async context => {
 	let diffMapping, lintState;
 	try {
 		[ lintState, diffMapping ] = await Promise.all([
-			runForRepo( pushConfig, getConfig( context ), github ),
+			runForRepo( pushConfig, getConfig( context, commit ), github ),
 			getDiffMapping( pushConfig, payload.number, github ),
 		]);
 	} catch ( e ) {
@@ -331,7 +331,7 @@ const onUpdatePull = async context => {
 	let diffMapping, lintState, previousState;
 	try {
 		[ lintState, diffMapping, previousState ] = await Promise.all([
-			runForRepo( pushConfig, getConfig( context ), github ),
+			runForRepo( pushConfig, getConfig( context, commit ), github ),
 			getDiffMapping( pushConfig, payload.number, github ),
 			getPreviousRun( github, owner, repo, payload.number ),
 		]);


### PR DESCRIPTION
Reads the hmlinter config from the commit being checked rather than the main branch, allowing it to follow regular PR change processes. I had hoped probot would fix this, but https://github.com/probot/probot/pull/1188 indicates they don't want to, so let's build our own config function.

Fixes #134.