### PR TITLE
Fix test and run processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ To get started on development of hm-linter:
 2. `npm install` or `yarn install` the dependencies
 
 
-### Testing
+## Testing
 
 ### Live Testing
 
 The easiest and best way to test hm-linter is to run the bot in development mode. This will run the bot locally, and uses a proxy to forward all webhook events from GitHub.
+
+`yarn start` will run a development copy of the linter bot inside a Lambda-like Docker container.
 
 To set this up:
 
@@ -106,6 +108,21 @@ A typical development process looks like this:
 6. If your code worked, you're done 🙌
 7. If your code didn't work, kill the bot
 8. Repeat steps 2-7 until your code works.
+
+
+### Testing Payloads
+
+You can test API Gateway payloads against a simulated Lambda environment (again using Docker) to do so:
+
+```sh
+# Run build at least once to download the bin and lib directories
+yarn run build
+
+# Pass a payload to the test command
+yarn run test < fixtures/lambda-test-event.json
+```
+
+**Note:** The format of this JSON data **must** be in API Gateway format; you typically want to copy this from CloudWatch Logs. If you get an `Cannot read property 'x-github-event' of undefined` error, you're passing a GitHub event instead.
 
 
 ### Simulation
@@ -157,9 +174,6 @@ Deployment can be done in one step by running the `deploy` script, but you shoul
 * `build` - Builds JS, downloads PHP binary, and installs Composer/npm dependencies.
 * `deploy:package` - Builds the directory into a zip. Use this to verify the ZIP before pushing.
 * `deploy:push` - Push the built zip to Lambda. Use this if `deploy` fails due to some sort of network error.
-* `test` - Run the index handler against a simulated Lambda environment. Before running this:
-	* Run `build` at least once
-	* Set the `AWS_LAMBDA_EVENT_BODY` environment variable to the contents of `fixtures/lambda-test-event.json` (`cat fixtures/lambda-test-event.json | read -z AWS_LAMBDA_EVENT_BODY`)
 
 
 ## Advanced Configuration

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,6 @@
+{
+	"watch": [
+		"./src",
+		"./start-development.js"
+	]
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "deploy:push-dev": "NODE_ENV=development run.env scripts/deploy.sh",
     "deploy": "npm run clean:package && npm run build && npm run deploy:check && npm run deploy:package-production && npm run deploy:push",
     "deploy:dev": "npm run clean:package && npm run build && npm run deploy:check-dev && npm run deploy:package-dev && npm run deploy:push-dev",
-    "start": "docker -- run -it --rm --env-file .env.dev -v \"$PWD\":/var/task:ro --entrypoint /var/task/node_modules/.bin/nodemon lambci/lambda:nodejs12.x /var/task/start-development.js",
+    "start": "docker run -it --rm --env-file .env.dev -v \"$PWD\":/var/task:ro --entrypoint /var/task/node_modules/.bin/nodemon lambci/lambda:nodejs12.x /var/task/start-development.js",
     "test": "docker run -i --rm --env-file .env -e DOCKER_LAMBDA_USE_STDIN=1 -v \"$PWD\":/var/task:ro lambci/lambda:nodejs12.x index.probotHandler"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "deploy:push-dev": "NODE_ENV=development run.env scripts/deploy.sh",
     "deploy": "npm run clean:package && npm run build && npm run deploy:check && npm run deploy:package-production && npm run deploy:push",
     "deploy:dev": "npm run clean:package && npm run build && npm run deploy:check-dev && npm run deploy:package-dev && npm run deploy:push-dev",
-    "start": "node start-development.js",
+    "start": "docker run --rm --env-file .env.dev -v \"$PWD\":/var/task:ro --entrypoint node lambci/lambda:nodejs12.x /var/task/start-development.js",
     "test": "docker run --rm --env-file .env -v \"$PWD\":/var/task:ro lambci/lambda:nodejs12.x index.probotHandler \"$AWS_LAMBDA_EVENT_BODY\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "dotenv": "^5.0.1",
+    "nodemon": "^2.0.4",
     "run.env": "^1.1.0"
   },
   "scripts": {
@@ -31,7 +32,7 @@
     "deploy:push-dev": "NODE_ENV=development run.env scripts/deploy.sh",
     "deploy": "npm run clean:package && npm run build && npm run deploy:check && npm run deploy:package-production && npm run deploy:push",
     "deploy:dev": "npm run clean:package && npm run build && npm run deploy:check-dev && npm run deploy:package-dev && npm run deploy:push-dev",
-    "start": "docker run --rm --env-file .env.dev -v \"$PWD\":/var/task:ro --entrypoint node lambci/lambda:nodejs12.x /var/task/start-development.js",
+    "start": "docker -- run -it --rm --env-file .env.dev -v \"$PWD\":/var/task:ro --entrypoint /var/task/node_modules/.bin/nodemon lambci/lambda:nodejs12.x /var/task/start-development.js",
     "test": "docker run --rm --env-file .env -v \"$PWD\":/var/task:ro lambci/lambda:nodejs12.x index.probotHandler \"$AWS_LAMBDA_EVENT_BODY\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "deploy": "npm run clean:package && npm run build && npm run deploy:check && npm run deploy:package-production && npm run deploy:push",
     "deploy:dev": "npm run clean:package && npm run build && npm run deploy:check-dev && npm run deploy:package-dev && npm run deploy:push-dev",
     "start": "node start-development.js",
-    "test": "docker run --env-file .env -v \"$PWD\":/var/task lambci/lambda:nodejs12.x index.probotHandler \"$AWS_LAMBDA_EVENT_BODY\""
+    "test": "docker run --rm --env-file .env -v \"$PWD\":/var/task:ro lambci/lambda:nodejs12.x index.probotHandler \"$AWS_LAMBDA_EVENT_BODY\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "deploy:push-dev": "NODE_ENV=development run.env scripts/deploy.sh",
     "deploy": "npm run clean:package && npm run build && npm run deploy:check && npm run deploy:package-production && npm run deploy:push",
     "deploy:dev": "npm run clean:package && npm run build && npm run deploy:check-dev && npm run deploy:package-dev && npm run deploy:push-dev",
-    "start": "docker run -it --rm --env-file .env.dev -v \"$PWD\":/var/task:ro --entrypoint /var/task/node_modules/.bin/nodemon lambci/lambda:nodejs12.x /var/task/start-development.js",
+    "start": "docker run -it --rm --env-file .env.dev -e NO_UPDATE_NOTIFIER=1 -v \"$PWD\":/var/task:ro --entrypoint /var/task/node_modules/.bin/nodemon lambci/lambda:nodejs12.x /var/task/start-development.js",
     "test": "docker run -i --rm --env-file .env -e DOCKER_LAMBDA_USE_STDIN=1 -v \"$PWD\":/var/task:ro lambci/lambda:nodejs12.x index.probotHandler"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "deploy": "npm run clean:package && npm run build && npm run deploy:check && npm run deploy:package-production && npm run deploy:push",
     "deploy:dev": "npm run clean:package && npm run build && npm run deploy:check-dev && npm run deploy:package-dev && npm run deploy:push-dev",
     "start": "docker -- run -it --rm --env-file .env.dev -v \"$PWD\":/var/task:ro --entrypoint /var/task/node_modules/.bin/nodemon lambci/lambda:nodejs12.x /var/task/start-development.js",
-    "test": "docker run --rm --env-file .env -v \"$PWD\":/var/task:ro lambci/lambda:nodejs12.x index.probotHandler \"$AWS_LAMBDA_EVENT_BODY\""
+    "test": "docker run -i --rm --env-file .env -e DOCKER_LAMBDA_USE_STDIN=1 -v \"$PWD\":/var/task:ro lambci/lambda:nodejs12.x index.probotHandler"
   }
 }

--- a/start-development.js
+++ b/start-development.js
@@ -1,9 +1,4 @@
-require( 'babel-polyfill' );
-
 const { probot } = require( '@humanmade/probot-util' );
-const path = require( 'path' );
-
-process.env['PATH'] = process.env['PATH'] + ':' + path.join( __dirname, 'bin' );
 
 // Probot setup
 const bot = probot.create();


### PR DESCRIPTION
This unifies the testing and running processes to use the Docker container consistently. It also adds live reload so that the node process is restarted (inside the container) using nodemon when any source files change.

After merging this, I'll fix up #105 to be compatible with this as well.