### PR TITLE
Add HTTP handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,4 +7,18 @@ const bot = probot.create();
 bot.load( require( './src' ) );
 
 // Lambda Handler
-module.exports.probotHandler = probot.buildHandler( bot );
+const handler = probot.buildHandler( bot );
+module.exports.probotHandler = function ( event, context, callback ) {
+	switch ( event.path ) {
+		// Pass check requests to HTTP.
+		case '/check':
+			const http = require( './src/http' );
+			http( event, context, callback )
+				.then( res => callback( null, res ) )
+				.catch( err => callback( err ) );
+			return;
+
+		default:
+			return handler( event, context, callback );
+	}
+};

--- a/src/config.js
+++ b/src/config.js
@@ -51,3 +51,5 @@ module.exports = async ( context, head ) => {
 		}
 	}
 };
+
+module.exports.DEFAULT_CONFIG = DEFAULT_CONFIG;

--- a/src/http.js
+++ b/src/http.js
@@ -30,11 +30,10 @@ module.exports = async ( event, context ) => {
 	console.log( event );
 	try {
 		if ( ! event.body ) {
-			console.log( 'no body' );
 			throw new ClientError( 'no_body', 'Missing body.' );
 		}
 
-		const data = new URLSearchParams( event.body );;
+		const data = new URLSearchParams( event.body );
 		let filename = data.get( 'filename' );
 
 		// Set default filename based on type.
@@ -55,7 +54,7 @@ module.exports = async ( event, context ) => {
 		const sanitizedFilename = filename.replace( /[^a-z0-9_\-.\/]+/gi, '' ).replace( /\.\//gi, '' );
 		if ( sanitizedFilename !== filename ) {
 			console.warn( 'Attempt to escape root' );
-			console.log( filename );
+			console.warn( filename );
 			throw new ClientError( 'no_file', 'Invalid filename.' );
 		}
 
@@ -70,7 +69,7 @@ module.exports = async ( event, context ) => {
 				const nextPart = fnParts.shift();
 				if ( nextPart === '..' || nextPart === '.' ) {
 					console.warn( 'Attempt to escape root' );
-					console.log( filename );
+					console.warn( filename );
 					throw new ClientError( 'invalid_path', 'Invalid path part' );
 				}
 
@@ -80,8 +79,8 @@ module.exports = async ( event, context ) => {
 		}
 
 		// Write code to the path.
-		const res = await pify( fs.writeFile )( path.join( dir, sanitizedFilename ), data.get( 'code' ) );
 		console.log( path.join( dir, sanitizedFilename ), res );
+		const res = await pify( fs.writeFile )( path.join( dir, sanitizedFilename ), data.get( 'code' ) );
 
 		// Then, prepare the linters.
 		const config = {

--- a/src/http.js
+++ b/src/http.js
@@ -1,0 +1,127 @@
+/**
+ * HTTP handler.
+ *
+ * This handler is responsible for handling web requests from lint-check.
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+const pify = require( 'pify' );
+
+const prepareLinters = require( './linters' );
+const { combineLinters } = require( './util' );
+
+class ClientError extends Error {
+	statusCode = 400;
+	code = null;
+
+	constructor( code, message ) {
+		super( message );
+		this.code = code;
+	}
+}
+
+const CORS_HEADERS = {
+	'Access-Control-Allow-Headers': 'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token',
+	'Access-Control-Allow-Methods': 'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT',
+	'Access-Control-Allow-Origin': '*',
+};
+
+module.exports = async ( event, context ) => {
+	console.log( event );
+	try {
+		if ( ! event.body ) {
+			console.log( 'no body' );
+			throw new ClientError( 'no_body', 'Missing body.' );
+		}
+
+		const data = new URLSearchParams( event.body );;
+		let filename = data.get( 'filename' );
+
+		// Set default filename based on type.
+		if ( ! filename ) {
+			switch ( data.get( 'type' ) ) {
+				case 'php':
+				case 'js':
+				case 'css':
+					filename = `file.${ data.get( 'type' ) }`;
+					break;
+
+				default:
+					throw new ClientError( 'invalid_type', 'Invalid type.' );
+			}
+		}
+
+		// Sanitize inputs.
+		const sanitizedFilename = filename.replace( /[^a-z0-9_\-.\/]+/gi, '' ).replace( /\.\//gi, '' );
+		if ( sanitizedFilename !== filename ) {
+			console.warn( 'Attempt to escape root' );
+			console.log( filename );
+			throw new ClientError( 'no_file', 'Invalid filename.' );
+		}
+
+		// First, save the input to a dummy file.
+		const dir = await pify( fs.mkdtemp )( '/tmp/lint' );
+
+		// If it's in a subfolder, make those.
+		const fnParts = sanitizedFilename.split( '/' );
+		if ( fnParts.length > 1 ) {
+			let baseDir = dir;
+			while ( fnParts.length > 1 ) {
+				const nextPart = fnParts.shift();
+				if ( nextPart === '..' || nextPart === '.' ) {
+					console.warn( 'Attempt to escape root' );
+					console.log( filename );
+					throw new ClientError( 'invalid_path', 'Invalid path part' );
+				}
+
+				baseDir = path.join( baseDir, nextPart );
+				await pify( fs.mkdir )( baseDir );
+			}
+		}
+
+		// Write code to the path.
+		const res = await pify( fs.writeFile )( path.join( dir, sanitizedFilename ), data.get( 'code' ) );
+		console.log( path.join( dir, sanitizedFilename ), res );
+
+		// Then, prepare the linters.
+		const config = {
+			version: data.get( 'version' ) || 'latest',
+			phpcs: {
+				enabled: true,
+				version: 'inherit',
+			},
+			eslint: {
+				enabled: true,
+				version: 'inherit',
+			},
+			stylelint: {
+				enabled: false,
+				version: 'inherit',
+			},
+		};
+		const linters = await prepareLinters( Promise.resolve( config ) );
+
+		// Run the linters.
+		const results = await Promise.all( linters.map( linter => linter( dir ) ) );
+
+		// Combine results.
+		const combined = combineLinters( results );
+
+		// return results;
+		return {
+			statusCode: 200,
+			headers: CORS_HEADERS,
+			body: JSON.stringify( combined ),
+		};
+	} catch ( err ) {
+		console.log( err );
+		return {
+			statusCode: err.statusCode || 500,
+			headers: CORS_HEADERS,
+			body: JSON.stringify( {
+				error: err.code || 'unknown',
+				message: err.message || '' + err,
+			} ),
+		};
+	}
+};

--- a/src/http.js
+++ b/src/http.js
@@ -7,6 +7,7 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 const pify = require( 'pify' );
 
+const { DEFAULT_CONFIG } = require( './config' );
 const prepareLinters = require( './linters' );
 const { combineLinters } = require( './util' );
 
@@ -84,19 +85,8 @@ module.exports = async ( event, context ) => {
 
 		// Then, prepare the linters.
 		const config = {
+			...DEFAULT_CONFIG,
 			version: data.get( 'version' ) || 'latest',
-			phpcs: {
-				enabled: true,
-				version: 'inherit',
-			},
-			eslint: {
-				enabled: true,
-				version: 'inherit',
-			},
-			stylelint: {
-				enabled: false,
-				version: 'inherit',
-			},
 		};
 		const linters = await prepareLinters( Promise.resolve( config ) );
 


### PR DESCRIPTION
This allows use via API Gateway in a web form, powering https://make.hmn.md/lint-check/

Requires API Gateway reconfiguration; hm-linter-development has that reconfiguration, but hm-linter does not yet. (Also, I've already deployed this to hm-linter-development.)

Sidenote: I spent a few hours trying to get API Gateway testing locally, and could not work it out, I don't think it's really possible. For testing this, unfortunately the best way is to use hm-linter-development so you get the actual event object from API Gateway. 😞 