### PR TITLE
Add some error-proofing to the metadata formatter

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -196,8 +196,12 @@ const formatAnnotations = ( state, baseUrl ) => {
 const formatMetadata = context => {
 	const { metadata, reqContext } = context;
 
+	if ( ! metadata ) {
+		return '';
+	}
+
 	let body = '<details><summary>Request details</summary><ul>';
-	body += `\n<li><strong>GitHub Event ID:</strong> <code>${ metadata.headers['X-GitHub-Delivery'] }</code></li>`;
+	body += `\n<li><strong>GitHub Event ID:</strong> <code>${ metadata.headers['X-GitHub-Delivery'] || 'UNKNOWN' }</code></li>`;
 	body += `\n<li><strong>API Gateway ID:</strong> <code>${ metadata.requestContext.requestId }</code></li>`;
 	body += `\n<li><strong>Lambda ID:</strong> <code>${ reqContext.awsRequestId }</code></li>`;
 	body += `\n<li><strong>Log Stream:</strong> <code>${ reqContext.logStreamName }</code></li>`;


### PR DESCRIPTION
Fixes a bug with running locally where there's not always metadata set.

#136 probably fixed this along the way, but just in case, let's make sure we don't crash.