### PR TITLE
Only include HM-Required if it exists

### DIFF
--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -68,12 +68,16 @@ module.exports = standardPath => codepath => {
 		const installedPaths = [
 			'vendor/fig-r/psr2r-sniffer',
 			'vendor/humanmade/coding-standards/HM',
-			'vendor/humanmade/coding-standards/HM-Required',
 			'vendor/phpcompatibility/php-compatibility',
 			'vendor/phpcompatibility/phpcompatibility-paragonie',
 			'vendor/phpcompatibility/phpcompatibility-wp',
 			'vendor/wp-coding-standards/wpcs',
 		]
+
+		// Only include HM-Required if the path exists within this version of the standards.
+		if ( fs.existsSync( path.join( standardPath, 'vendor', 'humanmade', 'coding-standards', 'HM-Required' ) ) ) {
+			installedPaths.push( 'vendor/humanmade/coding-standards/HM-Required' );
+		}
 
 		// Only include the VIP WPCS if the path exists within this version of the standards.
 		if ( fs.existsSync( path.join( standardPath, 'vendor', 'automattic', 'vipwpcs' ) ) ) {


### PR DESCRIPTION
This was causing older standards to fail.

(Note: will need updating when we rename, but in the meantime, let's not accidentally ship broken code.)