### PR TITLE
Default stylelint to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ eslint:
     version: inherit
 
 stylelint:
-    enabled: false
+    enabled: true
     version: inherit
 ```
 

--- a/src/config.js
+++ b/src/config.js
@@ -17,7 +17,7 @@ const DEFAULT_CONFIG = {
 		version: 'inherit',
 	},
 	stylelint: {
-		enabled: false,
+		enabled: true,
 		version: 'inherit',
 	},
 };


### PR DESCRIPTION
It seems I promised we'd turn on stylelint by default this week, so I figure I should make good on that 😄 This enables stylelint by default, fully completing #80.

I haven't tested this against the test repo, but this should be as simple as flipping the switch in the default config. I also obviously can't deploy the bot, so I'll leave that up to y'all.