### PR TITLE
Fix annotation chunk issue : Update check in loop to post all

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "probot": "^6.1.0",
     "rimraf": "^2.6.2",
     "serialize-error": "^2.1.0",
-    "smee-client": "^1.0.1",
+    "smee-client": "^1.2.2",
     "tar": "^4.0.1"
   },
   "devDependencies": {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -226,25 +226,27 @@ const onCheck = async context => {
 			throw e;
 		}
 
-		let annotations;
+		let annotationGroups;
 		if ( process.env.CHECK_ANNOTATION_ONLY_RELATED ) {
 			const currentAnnotations = formatAnnotations( lintState, `https://github.com/${owner}/${repo}/blob/${head_sha}`, diffMapping );
 
 			// Push annotations 50 at a time (and send the leftovers with the completion).
-			const annotationGroups = _chunk( currentAnnotations, 50 );
-			annotations = annotationGroups.pop();
+			annotationGroups = _chunk( currentAnnotations, 50 );
 		}
 
 		const summary = formatSummary( lintState );
 		const fullSummary = summary + `\n\n[View output](${ gistUrl })`;
-		completeRun(
-			'neutral',
-			{
-				title: lintState.passed ? 'All checks passed' : `Ignored ${ summary }`,
-				summary: fullSummary,
-				annotations,
-			}
-		);
+		// To create more than 50 annotations, we have to make multiple requests to the Update a check run 
+		annotationGroups.forEach( annotationGroup => {
+			completeRun(
+				'neutral',
+				{
+					title: lintState.passed ? 'All checks passed' : `Ignored ${ summary }`,
+					summary: fullSummary,
+					annotations: annotationGroup,
+				}
+			);
+		} )
 	} else if ( lintState.passed ) {
 		completeRun(
 			'success',

--- a/src/linters/phpcs/index.js
+++ b/src/linters/phpcs/index.js
@@ -104,6 +104,8 @@ module.exports = standardPath => codepath => {
 
 		const args = [
 			phpcsPath,
+			'-d',
+			'memory_limit=1G',
 			'-q',
 			'--runtime-set',
 			'installed_paths',


### PR DESCRIPTION
Currently, if we have 51 annotations then it will be posting only 1.

I also updated the logic to push all annotation so that it can render in the files. 

Example : https://github.com/humanmade/altis-code-review/pull/7/checks
